### PR TITLE
Add missing comma to param block for SharePoint versioning -Fixes #406

### DIFF
--- a/Extensions/Versioning/VersionSharepointAppManifestTask/ApplyBuildVersionToSharepointAppManifest.ps1
+++ b/Extensions/Versioning/VersionSharepointAppManifestTask/ApplyBuildVersionToSharepointAppManifest.ps1
@@ -20,7 +20,7 @@ param (
     [Parameter(Mandatory)]
     [string]$VersionNumber,
 
-    $InjectVersion
+    $InjectVersion,
     
     [string]$VersionRegex,
 

--- a/Extensions/Versioning/readme.md
+++ b/Extensions/Versioning/readme.md
@@ -95,3 +95,4 @@ The Android manifest versioner takes the following extra parameters:
 - V2.1.x  - Fix Android Versioning task from assigning a 0 to VersionCode, build will now fail if it is.
 - V2.2.x  - Issue398 fix for non Windows Platforms for tasks that run cross platform 
 - V2.3.x  - Issue306 added ability to inject a version number directly (no regex processing) to all tasks
+- V2.4.x  - Issue406 adding back in missing comma from parameter block in SharePoint task.


### PR DESCRIPTION
A comma was missed out of the parameter block for the Sharepoint versioning task and this is causing the task to fail. 