### PR TITLE
Revert "Force -AllowPrerelease to be false when calling Find-Module"

### DIFF
--- a/Extensions/Pester/readme.md
+++ b/Extensions/Pester/readme.md
@@ -50,4 +50,3 @@ Releases
 - 8.6.x - Fixed the installation of Pester from the PSGallery to use the first available PS Repository so it handles situations where only a private repository is available. [Fixes #366](https://github.com/rfennell/vNextBuild/issues/366)
 - 8.7.x - Fixed the installation of Pester to use whatever repository has the latest version available. This handles situations where the first private repository available doesn't have Pester or has an older version of Pester. [Fixes #366 Comment](https://github.com/rfennell/vNextBuild/issues/366#issuecomment-420618766)
 - 8.8.x - Add ScriptBlock parameter to allow running a script before running the tests. [Fixes #377](https://github.com/rfennell/vNextBuild/issues/377)
-- 8.9.x - Fix Find-Module so it doesn't attempt to find prerelease versions. [Fixes #412](https://github.com/rfennell/AzurePipelines/issues/412)

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -75,7 +75,7 @@ if ((Get-Module -Name PowerShellGet -ListAvailable) -and (Get-Command Install-Mo
     catch {
         Install-PackageProvider -Name Nuget -RequiredVersion 2.8.5.201 -Scope CurrentUser -Force -Confirm:$false
     }
-    $NewestPester = Find-Module -Name Pester -AllowPrerelease:$false | Sort-Object Version -Descending | Select-Object -First 1
+    $NewestPester = Find-Module -Name Pester | Sort-Object Version -Descending | Select-Object -First 1
     If ((Get-Module Pester -ListAvailable | Sort-Object Version -Descending| Select-Object -First 1).Version -lt $NewestPester.Version) {
         Install-Module -Name Pester -Scope CurrentUser -Force -Repository $NewestPester.Repository -SkipPublisherCheck
     }


### PR DESCRIPTION
Reverts rfennell/AzurePipelines#413

There are issues with this fix and we need to spend some more time on working on a better fix to this and testing it more thoroughly. 