### PR TITLE
Add catch to fallback to shipped pester if can't download nuget -fixes #447

### DIFF
--- a/Extensions/Pester/readme.md
+++ b/Extensions/Pester/readme.md
@@ -52,3 +52,4 @@ Releases
 - 8.8.x - Add ScriptBlock parameter to allow running a script before running the tests. [Fixes #377](https://github.com/rfennell/vNextBuild/issues/377)
 - 8.11.x - Fixing Find-Module issues raised in [#412](https://github.com/rfennell/AzurePipelines/issues/412) and [415](https://github.com/rfennell/AzurePipelines/issues/415) by adding a check for AllowPrerelease switch on the cmdlet. If it's not available we'll fall back to the version of Pester that is shipped with the extension and write a warning that a newer version can't be used without a newer version of PowerShellGet being available.
 - 8.12.x - Updating built in version of Pester to 4.6.0. Remove check for AllowPrerelease as it's not needed. Fixes [#421](https://github.com/rfennell/AzurePipelines/issues/421)
+- 8.13.x - Update to better support offline build machines with no nuget installed. Falls back to shipped version of Pester. Fixes [#447](https://github.com/rfennell/AzurePipelines/issues/447)

--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -75,7 +75,13 @@ if ((Get-Module -Name PowerShellGet -ListAvailable) -and
         $null = Get-PackageProvider -Name NuGet -ErrorAction Stop
     }
     catch {
-        Install-PackageProvider -Name Nuget -RequiredVersion 2.8.5.201 -Scope CurrentUser -Force -Confirm:$false
+        try {
+            Install-PackageProvider -Name Nuget -RequiredVersion 2.8.5.201 -Scope CurrentUser -Force -Confirm:$false -ErrorAction Stop
+        }
+        catch {
+            Write-Host "##vos[task.logissue type=warning]Falling back to version of Pester shipped with extension. To use a newer version please update the version of PowerShellGet available on this machine."
+            Import-Module "$PSScriptRoot\4.6.0\Pester.psd1" -force
+        }
     }
     $NewestPester = Find-Module -Name Pester | Sort-Object Version -Descending | Select-Object -First 1
     If ((Get-Module Pester -ListAvailable | Sort-Object Version -Descending| Select-Object -First 1).Version -lt $NewestPester.Version) {


### PR DESCRIPTION
When no internet access was available to download nuget the task was failing. Now we fall back to the shipped version of pester.