### PR TITLE
Fix Version .NET Core Assemblies fails with "Unexpected token ="

### DIFF
--- a/Extensions/Versioning/VersionDotNetCoreAssembliesTask/task/task.json
+++ b/Extensions/Versioning/VersionDotNetCoreAssembliesTask/task/task.json
@@ -2,7 +2,7 @@
   "id": "4578fa22-6039-4d83-90e0-3e12f68d6b26",
   "name": "VersionDotNetCoreAssemblies",
   "friendlyName": "Version .NET Core Assemblies",
-  "description": "Applies a version to a .NET Core assembly via the .cspro files based on the build number. Based on Microsoft sample from https://msdn.microsoft.com/Library/vs/alm/Build/overview",
+  "description": "Applies a version to a .NET Core assembly via the .csproj files based on the build number. Based on Microsoft sample from https://msdn.microsoft.com/Library/vs/alm/Build/overview",
      "helpMarkDown": "Version: #{Build.BuildNumber}#. [More Information](https://github.com/rfennell/vNextBuild/wiki/Version-Assemblies-and-Packages-Tasks/)",
  "category": "Build",
   "visibility": [
@@ -42,7 +42,7 @@
          "label": "Version Number",
          "defaultValue": "$(Build.BuildNumber)",
          "required": true,
-         "helpMarkDown": "Version number to apply to files, can be extraced from the build name 'Build HelloWorld_00.00.00000.0' format"
+         "helpMarkDown": "Version number to apply to files, can be extracted from the build name 'Build HelloWorld_00.00.00000.0' format"
       },
       {
         "name": "Injectversion",
@@ -101,7 +101,7 @@
     }
       
    ],
-  "minimumAgentVersion": "1.82.0",
+  "minimumAgentVersion": "1.95.1",
    "instanceNameFormat": "Version .NET Core Assemblies",
   "execution": {
      "Node": {

--- a/Extensions/Versioning/VersionDotNetCoreAssembliesTask/tsconfig.json
+++ b/Extensions/Versioning/VersionDotNetCoreAssembliesTask/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "ES6",
+        "target": "ES5",
         "module": "commonjs",
          "watch": false,
          "outDir": "../VersionDotNetCoreAssembliesTask/",


### PR DESCRIPTION
### What problem does this PR address?
The Version .NET Core Assemblies task fails when executed on a TFS 2015.4 build agent.
  
### Is there a related Issue?
https://github.com/rfennell/AzurePipelines/issues/457
  
### Have you...
- Added a new release line entry in to the extensions readme.md file (the list is usually found at the end of the file) that 
  - increments the minor version number e.g. 1.2 to 1.3
  - lists the Issue/PR number related to the change
  - provides a brief single line comment as to the change made
  - if the change adds new parameters update the appropriate documentation

> NOTE: I did not modify readme.md as there was no existing release history in this one. Also, it seems that you have a separate versioning system so I wasn't sure if you needed any versions bumped in your PR.

- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
