### PR TITLE
allow zero or more spaces between the equals sign (instead of 1 or mo…

### DIFF
--- a/Extensions/Versioning/VersionWixTask/ApplyBuildVersionToWix.ps1
+++ b/Extensions/Versioning/VersionWixTask/ApplyBuildVersionToWix.ps1
@@ -31,11 +31,11 @@ function ReplaceVersion {
     )
 
     # regex for a single digit replace
-    $regex = "<\?define\s+{0}\s+=\s+\""\d+\""\s+\?>"
+    $regex = "<\?define\s+{0}\s*=\s*\""\d+\""\s+\?>"
     if ([regex]::IsMatch($value , "\d+\.\d+\.\d+\.\d+"))
     {
         # we need to handle a full version
-        $regex = "<\?define\s+{0}\s+=\s+\""\d+\.\d+\.\d+\.\d+\""\s+\?>"
+        $regex = "<\?define\s+{0}\s*=\s*\""\d+\.\d+\.\d+\.\d+\""\s+\?>"
     }
 
     return $contents -replace  [string]::Format($regex, $name),  [string]::Format("<?define {0} = ""{1}"" ?>", $name, $value)


### PR DESCRIPTION
…re spaces)

### What problem does this PR address?
Given a wxi file, when I have a variable without a space character around the equal sign, the value substitution will not occur due to the regex not matching.

For example, before the change, this line would not substitute the value (note no spaces around the '=' sign):

<?define MajorVersion="1" ?>
