### PR TITLE
#494 fixes to the regex matching for multiple matches

### DIFF
--- a/Extensions/Versioning/VersionDotNetCoreAssembliesTask/test/FileProcessingTest.ts
+++ b/Extensions/Versioning/VersionDotNetCoreAssembliesTask/test/FileProcessingTest.ts
@@ -150,3 +150,49 @@ describe("Test the 483 file processing", () => {
   });
 
 });
+
+describe("Test the 494 file processing for singe field", () => {
+  before(function() {
+    // make a copy we can overwrite without breaking test data
+    copyFileSync("test/testdata/core494.csproj.initial", "test/testdata/core.csproj");
+  });
+
+  it("should be able to edit AssemblyVersion field in a file", () => {
+    var file = "test/testdata/core.csproj";
+    ProcessFile(file, "AssemblyVersion", "9.9.9.9", true);
+
+    var editedfilecontent = fs.readFileSync(file);
+    var expectedfilecontent = fs.readFileSync(`test/testdata/core494.csproj.expected`);
+
+    expect(editedfilecontent.toString()).equals(expectedfilecontent.toString());
+  });
+
+  after(function() {
+    // remove the file if created
+    del.sync("test/testdata/*.csproj");
+  });
+
+});
+
+describe("Test the 494 file processing for all fields", () => {
+  before(function() {
+    // make a copy we can overwrite without breaking test data
+    copyFileSync("test/testdata/core494.csproj.initial", "test/testdata/core.csproj");
+  });
+
+  it("should be able to edit all version field in a file", () => {
+    var file = "test/testdata/core.csproj";
+    ProcessFile(file, "", "9.9.9.9", true);
+
+    var editedfilecontent = fs.readFileSync(file);
+    var expectedfilecontent = fs.readFileSync(`test/testdata/core494.csproj.expected`);
+
+    expect(editedfilecontent.toString()).equals(expectedfilecontent.toString());
+  });
+
+  after(function() {
+    // remove the file if created
+    del.sync("test/testdata/*.csproj");
+  });
+
+});

--- a/Extensions/Versioning/VersionDotNetCoreAssembliesTask/test/FindFilesTests.ts
+++ b/Extensions/Versioning/VersionDotNetCoreAssembliesTask/test/FindFilesTests.ts
@@ -14,7 +14,7 @@ describe("Test the find file processing", () => {
 
   it("should be able to find only .netcore project files", () => {
       var files = findFiles(`test/testdata`, ".csproj.initial", files);
-      expect(files.length).equals(5);
+      expect(files.length).equals(6);
     });
 
   });

--- a/Extensions/Versioning/VersionDotNetCoreAssembliesTask/test/testdata/core494.csproj.expected
+++ b/Extensions/Versioning/VersionDotNetCoreAssembliesTask/test/testdata/core494.csproj.expected
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <AssemblyVersion>9.9.9.9</AssemblyVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/Extensions/Versioning/VersionDotNetCoreAssembliesTask/test/testdata/core494.csproj.initial
+++ b/Extensions/Versioning/VersionDotNetCoreAssembliesTask/test/testdata/core494.csproj.initial
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <AssemblyVersion>1.2.3.4</AssemblyVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Fix for the .NET Core versioner. The switch to regex for block matching causing a problem if there are duplicate blocks. Now assume that we use the first block found.