### PR TITLE
Ensure version number gets parsed from a regex match

### DIFF
--- a/Extensions/Versioning/VersionDacpacTask/src/Update-DacPacVersionNumber.ps1
+++ b/Extensions/Versioning/VersionDacpacTask/src/Update-DacPacVersionNumber.ps1
@@ -269,7 +269,7 @@ else {
 
         foreach ($SqlProj in $SqlProjFiles) {
             Write-Verbose "Updating $($SqlProj.Basename) SQL Proj file."
-            Update-SqlProjVersion -Path $SqlProj.Fullname -VersionNumber $NewVersion -RegexPattern $VersionRegex
+            Update-SqlProjVersion -Path $SqlProj.Fullname -VersionNumber ([System.Version]::Parse($NewVersion)) -RegexPattern $VersionRegex
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR address?
RegexMatch doesn't convert to System.Version neatly, need to add a call to parse it.
  
