### PR TITLE
Fix regression in build variables for resource groups

### DIFF
--- a/Extensions/BuildUpdating/readme.md
+++ b/Extensions/BuildUpdating/readme.md
@@ -61,6 +61,8 @@ Add permission to edit the build definition
 
 #### For Variables Groups 
 
+Notes: Note supported in TFS 2017 due to lack of API calls
+
 Add permission to edit the variable group definition
 
 1. In a browser select the Library tab


### PR DESCRIPTION
1.15.x introduced a regression so variable groups could not be updated
Logic has been added to pick the correct API version to support TFS 2017 (2.0 or 3.0) and variable groups in later versions of Azure DevOps (4.0)