### PR TITLE
Add support for specifying prerelease flags in the versioning of PowerShell modules -Fixes #547

### DIFF
--- a/Extensions/Versioning/VersionPowerShellModule/test/Update-PowerShellModuleVersion.Tests.ps1
+++ b/Extensions/Versioning/VersionPowerShellModule/test/Update-PowerShellModuleVersion.Tests.ps1
@@ -8,7 +8,9 @@ Describe "Testing Update-PowerShellModuleVersion.ps1" {
 
     Context "Testing Processing" {
         Function Update-MetaData {}
+        Function Get-MetaData {}
 #        Mock -CommandName Write-Verbose -MockWith {}
+        Mock -CommandName Write-Warning -MockWith {}
         Mock -CommandName Write-Error -MockWith {}
         Mock -CommandName Get-PackageProvider -MockWith {}
         Mock -CommandName Install-PackageProvider -MockWith {}
@@ -32,6 +34,7 @@ Describe "Testing Update-PowerShellModuleVersion.ps1" {
                 Path = 'TestDrive:\First.psd1'
             }
         }
+        Mock -CommandName Get-MetaData -MockWith {$true}
         #Mock -CommandName Select-Object -MockWith {}
 
         It "Should write an error when the version number isn't a valid format" {
@@ -120,6 +123,36 @@ Describe "Testing Update-PowerShellModuleVersion.ps1" {
             &$Sut 
 
             Assert-MockCalled -CommandName Update-Metadata -Scope It -Times 2
+        }
+        It "Should attempt to update the version number and private data in 1 module in the target path when a prerelease version is passed" {
+
+            Mock Get-VstsInput -ParameterFilter {$Name -eq "Path"} {return 'TestDrive:\'}
+            Mock Get-VstsInput -ParameterFilter {$Name -eq "VersionNumber"} {return "1.2.3.4-alpha"}
+            Mock Get-VstsInput -ParameterFilter {$Name -eq "InjectVersion"} {return "true"}
+            Mock Get-VstsInput -ParameterFilter {$Name -eq "VersionRegex"} {return "\d+\.\d+\.\d+\.\d+"}
+            Mock Get-VstsInput -ParameterFilter {$Name -eq "outputversion"} {return ""}
+            Mock -CommandName Select-Object -MockWith {'TestDrive:\First.psd1'} -ParameterFilter {$InputObject.Path -eq 'TestDrive:\First.psd1'}
+
+            &$Sut 
+
+            Assert-MockCalled -CommandName Update-Metadata -Scope It -Times 2
+        }
+        It "Should write a warning when the PSData Prerelease section isn't in the manifest when a prerelease version is passed" {
+
+            Mock Get-VstsInput -ParameterFilter {$Name -eq "Path"} {return 'TestDrive:\'}
+            Mock Get-VstsInput -ParameterFilter {$Name -eq "VersionNumber"} {return "1.2.3.4-alpha"}
+            Mock Get-VstsInput -ParameterFilter {$Name -eq "InjectVersion"} {return "true"}
+            Mock Get-VstsInput -ParameterFilter {$Name -eq "VersionRegex"} {return "\d+\.\d+\.\d+\.\d+"}
+            Mock Get-VstsInput -ParameterFilter {$Name -eq "outputversion"} {return ""}
+            Mock -CommandName Select-Object -MockWith {'TestDrive:\First.psd1'} -ParameterFilter {$InputObject.Path -eq 'TestDrive:\First.psd1'}
+            Mock -CommandName Get-MetaData -MockWith {$null}
+            &$Sut 
+
+            Assert-MockCalled -CommandName Update-Metadata -Scope It -Times 1
+            Assert-MockCalled -CommandName Write-Warning -Scope It -Times 1 -ParameterFilter {
+                $Message -eq ("Cannot set Prerelease in module manifest. Add an empty Prerelease to your module manifest, like:`n" +
+                '         PrivateData = @{ PSData = @{ Prerelease = "" } }')
+            }
         }
     }
 }


### PR DESCRIPTION
### What problem does this PR address?

Versioning PowerShell modules doesn't handle prerelease versioning, this will fix that by adding the prerelease flag to the PrivateData section of the manifest.

### Is there a related Issue?
#547 
