### PR TITLE
Angular Version: allow the use of double quotes for the version field

### DIFF
--- a/Extensions/Versioning/VersionAngularFileTask/src/AppyVersionToAngularFileFunctions.ts
+++ b/Extensions/Versioning/VersionAngularFileTask/src/AppyVersionToAngularFileFunctions.ts
@@ -99,7 +99,7 @@ export function ProcessFile(file, field, newVersion) {
     } else {
         if (field && field.length > 0) {
             console.log (`Updating the field '${field}' version`);
-            const versionRegex = `(${field}:.*')(.*)(')`;
+            const versionRegex = `(${field}:.*["'])(.*)(["'])`;
             var regexp = new RegExp(versionRegex, "gmi");
             let content: string = filecontent.toString();
             let matches;

--- a/Extensions/Versioning/VersionAngularFileTask/test/FileProcessingTest.ts
+++ b/Extensions/Versioning/VersionAngularFileTask/test/FileProcessingTest.ts
@@ -85,3 +85,26 @@ describe("Test the version extraction", () => {
   });
 
 });
+
+describe("Test for Issue 615 double quotes", () => {
+  before(function() {
+    // make a copy we can overright with breaking test data
+    copyFileSync("test/testdata/issue615-environment.ts.initial", "test/testdata/environment.ts");
+  });
+
+  it("should be able to update a version in a file", () => {
+    var file = "test/testdata/environment.ts";
+    ProcessFile(file, "version", "1.2.3.4");
+
+    var editedfilecontent = fs.readFileSync(file);
+    var expectedfilecontent = fs.readFileSync(`test/testdata/issue615-environment.ts.expected`);
+
+    expect(editedfilecontent.toString()).equals(expectedfilecontent.toString());
+  });
+
+  after(function() {
+    // remove the file if created
+    del.sync("test/testdata/environment.ts");
+  });
+}
+);

--- a/Extensions/Versioning/VersionAngularFileTask/test/FindFilesTests.ts
+++ b/Extensions/Versioning/VersionAngularFileTask/test/FindFilesTests.ts
@@ -10,7 +10,7 @@ describe ("Find files tests", () => {
 
     it ("should be able to find one file", () => {
         var filelist = findFiles ("test/testdata", "environment.ts.initial" , filelist);
-        expect(filelist.length).to.equal(1);
+        expect(filelist.length).to.equal(2);
     });
 
     it ("should be able to use a wildcard to find two files", () => {

--- a/Extensions/Versioning/VersionAngularFileTask/test/testdata/issue615-environment.ts.expected
+++ b/Extensions/Versioning/VersionAngularFileTask/test/testdata/issue615-environment.ts.expected
@@ -1,0 +1,4 @@
+export const environment = {
+production: true,
+version: "1.2.3.4"
+};

--- a/Extensions/Versioning/VersionAngularFileTask/test/testdata/issue615-environment.ts.initial
+++ b/Extensions/Versioning/VersionAngularFileTask/test/testdata/issue615-environment.ts.initial
@@ -1,0 +1,4 @@
+export const environment = {
+production: true,
+version: "1.0.0.0"
+};


### PR DESCRIPTION
### What problem does this PR address?
Addresses issue #614

Allows the use of double quotes in the `environment.ts` file to be versioned.
