### PR TITLE
Added support for Handlebars template library

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/V2/GenerateReleaseNotes.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V2/GenerateReleaseNotes.ts
@@ -43,7 +43,7 @@ async function run(): Promise<number>  {
             }
 
             if (fieldEquality === delimiter) {
-                agentApi.logError (`The delimiter and fieldequality parameters cannot be the same, plase change one. The usual defaults a : and = respectivally`);
+                agentApi.logError (`The delimiter and field equality parameters cannot be the same, please change one. The usual defaults a : and = respectively`);
             }
 
             var stopOnRedeploy = tl.getBoolInput("stopOnRedeploy");

--- a/Extensions/XplatGenerateReleaseNotes/V2/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V2/ReleaseNotesFunctions.ts
@@ -22,6 +22,7 @@ import { GitCommit } from "vso-node-api/interfaces/GitInterfaces";
 import { HttpClient } from "typed-rest-client/HttpClient";
 import { WorkItem } from "vso-node-api/interfaces/WorkItemTrackingInterfaces";
 import { type } from "os";
+const Handlebars = require("handlebars");
 
 let agentApi = new AgentSpecificApi();
 
@@ -152,13 +153,22 @@ export function getTemplate(
     ): Array<string> {
         agentApi.logDebug(`Using template mode ${templateLocation}`);
         var template;
+        const handlebarIndicator = '{{';
         if (templateLocation === "File") {
             agentApi.logInfo (`Loading template file ${templatefile}`);
-        template = fs.readFileSync(templatefile).toString().split("\n");
+            template = fs.readFileSync(templatefile).toString();
         } else {
             agentApi.logInfo ("Using in-line template");
+            template = inlinetemplate;
+        }
+        // handlebar templates won't be processed line-by-line so don't split them
+        if (template.includes(handlebarIndicator)) {
+            agentApi.logDebug("Loading handlebar template");
+        }
+        else {
+            agentApi.logDebug("Loading legacy template");
             // it appears as single line we need to split it out
-            template = inlinetemplate.split("\n");
+            template = template.split("\n");
         }
         return template;
 }
@@ -175,246 +185,262 @@ export function processTemplate(template, workItems: WorkItem[], commits: Change
         agentApi.logDebug("Processing template");
         agentApi.logDebug(`WI: ${workItems.length}`);
         agentApi.logDebug(`CS: ${commits.length}`);
-        // create our work stack and initialise
-        var modeStack = [];
 
-        addStackItem (null, modeStack, Mode.BODY, -1);
+        // if it's an array, it's a legacy template
+        if (Array.isArray(template)) {
 
-        // process each line
-        for (var index = 0; index < template.length; index++) {
-           agentApi.logDebug(`${addSpace(modeStack.length + 1)} Processing Line No: ${(index + 1)}`);
-           var line = template[index];
-           // agentApi.logDebug("Line: " + line);
-           // get the line mode (if any)
-           var mode = getMode(line);
-           var wiFilter = getWIModeTags(line, delimiter, fieldEquality);
-           var csFilter = getCSFilter(line);
+            agentApi.logDebug("Processing legacy template");
 
-           if (mode !== Mode.BODY) {
-               // is there a mode block change
-              if (getMode(modeStack[modeStack.length - 1].BlockMode) === mode) {
-                  // this means we have reached the end of a block
-                  // need to work out if there are more items to process
-                  // or the end of the block
-                  var queue = modeStack[modeStack.length - 1].BlockQueue;
-                  if (queue.length > 0) {
-                      // get the mode items and initialise
-                      // the variables exposed to the template
-                      var item = queue.shift();
-                      // reset the index to process the block
-                      index = modeStack[modeStack.length - 1].Index;
-                      switch (mode) {
-                        case Mode.WI :
-                            agentApi.logDebug (`${addSpace(modeStack.length + 1)} Getting next workitem ${item.id}`);
-                            widetail = item; // should filter
-                            break;
-                        case Mode.CS :
-                            if (csdetail.type.toLowerCase() === "tfsgit") {
-                                // Git mode
-                                agentApi.logDebug (`${addSpace(modeStack.length + 1)} Getting next commit ${item.id}`);
-                            } else {
-                                // TFVC mode
-                                agentApi.logDebug (`${addSpace(modeStack.length + 1)} Getting next changeset ${item.id}`);
-                            }
-                             csdetail = item;
-                             break;
-                      } // end switch
+            // create our work stack and initialise
+            var modeStack = [];
+
+            addStackItem (null, modeStack, Mode.BODY, -1);
+
+            // process each line
+            for (var index = 0; index < template.length; index++) {
+               agentApi.logDebug(`${addSpace(modeStack.length + 1)} Processing Line No: ${(index + 1)}`);
+               var line = template[index];
+               // agentApi.logDebug("Line: " + line);
+               // get the line mode (if any)
+               var mode = getMode(line);
+               var wiFilter = getWIModeTags(line, delimiter, fieldEquality);
+               var csFilter = getCSFilter(line);
+
+               if (mode !== Mode.BODY) {
+                   // is there a mode block change
+                  if (getMode(modeStack[modeStack.length - 1].BlockMode) === mode) {
+                      // this means we have reached the end of a block
+                      // need to work out if there are more items to process
+                      // or the end of the block
+                      var queue = modeStack[modeStack.length - 1].BlockQueue;
+                      if (queue.length > 0) {
+                          // get the mode items and initialise
+                          // the variables exposed to the template
+                          var item = queue.shift();
+                          // reset the index to process the block
+                          index = modeStack[modeStack.length - 1].Index;
+                          switch (mode) {
+                            case Mode.WI :
+                                agentApi.logDebug (`${addSpace(modeStack.length + 1)} Getting next workitem ${item.id}`);
+                                widetail = item; // should filter
+                                break;
+                            case Mode.CS :
+                                if (csdetail.type.toLowerCase() === "tfsgit") {
+                                    // Git mode
+                                    agentApi.logDebug (`${addSpace(modeStack.length + 1)} Getting next commit ${item.id}`);
+                                } else {
+                                    // TFVC mode
+                                    agentApi.logDebug (`${addSpace(modeStack.length + 1)} Getting next changeset ${item.id}`);
+                                }
+                                 csdetail = item;
+                                 break;
+                          } // end switch
+                      } else {
+                          // end of block and no more items, so exit the block
+                          var blockMode = modeStack.pop().BlockMode;
+                          agentApi.logDebug (`${addSpace(modeStack.length + 1)} Ending block ${blockMode}`);
+                      }
                   } else {
-                      // end of block and no more items, so exit the block
-                      var blockMode = modeStack.pop().BlockMode;
-                      agentApi.logDebug (`${addSpace(modeStack.length + 1)} Ending block ${blockMode}`);
-                  }
-              } else {
-                  // this a new block to add the stack
-                  // need to get the items to process and place them in a queue
-                  agentApi.logDebug (`${addSpace(modeStack.length + 1)} Starting block ${line}`);
-                  // set the index to jump back to
-                  lastBlockStartIndex = index;
-                  switch (mode) {
-                      case Mode.WI:
-                        // store the block and load the first item
-                        // Need to check if we are in tag mode
-                        var modeArray = [];
-                        if (wiFilter.tags.length > 0 || wiFilter.fields.length > 0) {
-                            widetail = undefined;
-                            var parts;
-                            var okToAdd;
-                            workItems.forEach(wi => {
-                                agentApi.logDebug (`${addSpace(modeStack.length + 2)} Checking WI ${wi.id} with tags '${wi.fields["System.Tags"]}' against tags '${wiFilter.tags.sort().join("; ")}' and fields '${wiFilter.fields.sort().join("; ")}' using comparison filter '${wiFilter.modifier}'`);
-                                switch (wiFilter.modifier) {
-                                    case Modifier.All:
-                                        agentApi.logDebug (`${addSpace(modeStack.length + 4)} Using ALL filter`);
-                                        if (wiFilter.tags.length > 0) {
-                                            if ((wi.fields["System.Tags"] !== undefined) &&
-                                                (wi.fields["System.Tags"].toUpperCase() === wiFilter.tags.join("; ").toUpperCase())) {
-                                                agentApi.logDebug (`${addSpace(modeStack.length + 4)} Tags match, need to check fields`);
-                                                okToAdd = true;
+                      // this a new block to add the stack
+                      // need to get the items to process and place them in a queue
+                      agentApi.logDebug (`${addSpace(modeStack.length + 1)} Starting block ${line}`);
+                      // set the index to jump back to
+                      lastBlockStartIndex = index;
+                      switch (mode) {
+                          case Mode.WI:
+                            // store the block and load the first item
+                            // Need to check if we are in tag mode
+                            var modeArray = [];
+                            if (wiFilter.tags.length > 0 || wiFilter.fields.length > 0) {
+                                widetail = undefined;
+                                var parts;
+                                var okToAdd;
+                                workItems.forEach(wi => {
+                                    agentApi.logDebug (`${addSpace(modeStack.length + 2)} Checking WI ${wi.id} with tags '${wi.fields["System.Tags"]}' against tags '${wiFilter.tags.sort().join("; ")}' and fields '${wiFilter.fields.sort().join("; ")}' using comparison filter '${wiFilter.modifier}'`);
+                                    switch (wiFilter.modifier) {
+                                        case Modifier.All:
+                                            agentApi.logDebug (`${addSpace(modeStack.length + 4)} Using ALL filter`);
+                                            if (wiFilter.tags.length > 0) {
+                                                if ((wi.fields["System.Tags"] !== undefined) &&
+                                                    (wi.fields["System.Tags"].toUpperCase() === wiFilter.tags.join("; ").toUpperCase())) {
+                                                    agentApi.logDebug (`${addSpace(modeStack.length + 4)} Tags match, need to check fields`);
+                                                    okToAdd = true;
+                                                } else {
+                                                    agentApi.logDebug (`${addSpace(modeStack.length + 4)} Tags do not match, no need to check fields`);
+                                                    okToAdd = false;
+                                                }
                                             } else {
-                                                agentApi.logDebug (`${addSpace(modeStack.length + 4)} Tags do not match, no need to check fields`);
-                                                okToAdd = false;
+                                                agentApi.logDebug (`${addSpace(modeStack.length + 4)} No tags in filter to match, need to check fields`);
+                                                okToAdd = true;
                                             }
-                                        } else {
-                                            agentApi.logDebug (`${addSpace(modeStack.length + 4)} No tags in filter to match, need to check fields`);
-                                            okToAdd = true;
-                                        }
-                                        if (okToAdd && wiFilter.fields.length > 0) {
-                                            for (let field of wiFilter.fields) {
-                                                parts = field.split("=");
-                                                agentApi.logDebug (`${addSpace(modeStack.length + 4)} Comparing field '${parts[0]}' contents '${wi.fields[parts[0]]}' to '${parts[1]}'`);
-                                                if (parts[1] === anyFieldContent) {
-                                                    agentApi.logDebug (`${addSpace(modeStack.length + 4)} The contents match is the 'any data value`);
-                                                    if (wi.fields[parts[0]] === undefined) {
-                                                        agentApi.logDebug (`${addSpace(modeStack.length + 4)} Field does not exist`);
+                                            if (okToAdd && wiFilter.fields.length > 0) {
+                                                for (let field of wiFilter.fields) {
+                                                    parts = field.split("=");
+                                                    agentApi.logDebug (`${addSpace(modeStack.length + 4)} Comparing field '${parts[0]}' contents '${wi.fields[parts[0]]}' to '${parts[1]}'`);
+                                                    if (parts[1] === anyFieldContent) {
+                                                        agentApi.logDebug (`${addSpace(modeStack.length + 4)} The contents match is the 'any data value`);
+                                                        if (wi.fields[parts[0]] === undefined) {
+                                                            agentApi.logDebug (`${addSpace(modeStack.length + 4)} Field does not exist`);
+                                                            okToAdd = false;
+                                                            break;
+                                                        } else {
+                                                            agentApi.logDebug (`${addSpace(modeStack.length + 4)} Field exists`);
+                                                        }
+                                                    } else if (wi.fields[parts[0]] !== parts[1]) {
+                                                        agentApi.logDebug (`${addSpace(modeStack.length + 4)} Field does not match`);
                                                         okToAdd = false;
                                                         break;
                                                     } else {
-                                                        agentApi.logDebug (`${addSpace(modeStack.length + 4)} Field exists`);
+                                                        agentApi.logDebug (`${addSpace(modeStack.length + 4)} Field matches`);
                                                     }
-                                                } else if (wi.fields[parts[0]] !== parts[1]) {
-                                                    agentApi.logDebug (`${addSpace(modeStack.length + 4)} Field does not match`);
-                                                    okToAdd = false;
-                                                    break;
-                                                } else {
-                                                    agentApi.logDebug (`${addSpace(modeStack.length + 4)} Field matches`);
                                                 }
                                             }
-                                        }
-                                        if (okToAdd) {
-                                            agentApi.logDebug (`${addSpace(modeStack.length + 4)} Adding WI ${wi.id} as all tags and fields match`);
-                                            modeArray.push(wi);
-                                        }
-                                        break;
-                                    case Modifier.ANY:
-                                        agentApi.logDebug (`${addSpace(modeStack.length + 4)} Using ANY filter`);
-                                        okToAdd = false;
-                                        if ((wi.fields["System.Tags"] !== undefined) && (wiFilter.tags.length > 0)) {
-                                            for (let tag of wiFilter.tags) {
-                                                agentApi.logDebug (`${addSpace(modeStack.length + 4)} Checking tag ${tag}`);
-                                                if (wi.fields["System.Tags"].toUpperCase().indexOf(tag.toUpperCase()) !== -1) {
-                                                    agentApi.logDebug (`${addSpace(modeStack.length + 4)} Found match on tag`);
-                                                    okToAdd = true;
-                                                    break;
-                                                } else {
-                                                    agentApi.logDebug (`${addSpace(modeStack.length + 4)} No match on tag`);
-                                                }
+                                            if (okToAdd) {
+                                                agentApi.logDebug (`${addSpace(modeStack.length + 4)} Adding WI ${wi.id} as all tags and fields match`);
+                                                modeArray.push(wi);
                                             }
-                                        } else {
-                                            agentApi.logDebug (`${addSpace(modeStack.length + 4)} No tags to check, checking fields`);
-                                        }
-                                        if (okToAdd === false) {
-                                            for (let field of wiFilter.fields) {
-                                                parts = field.split("=");
-                                                agentApi.logDebug (`${addSpace(modeStack.length + 4)} Comparing field '${parts[0]}' contents '${wi.fields[parts[0]]}' to '${parts[1]}'`);
-                                                if (parts[1] === anyFieldContent) {
-                                                    agentApi.logDebug (`${addSpace(modeStack.length + 4)} The contents match is the 'any data value`);
-                                                    if (wi.fields[parts[0]] !== undefined) {
-                                                        agentApi.logDebug (`${addSpace(modeStack.length + 4)} Field exist`);
+                                            break;
+                                        case Modifier.ANY:
+                                            agentApi.logDebug (`${addSpace(modeStack.length + 4)} Using ANY filter`);
+                                            okToAdd = false;
+                                            if ((wi.fields["System.Tags"] !== undefined) && (wiFilter.tags.length > 0)) {
+                                                for (let tag of wiFilter.tags) {
+                                                    agentApi.logDebug (`${addSpace(modeStack.length + 4)} Checking tag ${tag}`);
+                                                    if (wi.fields["System.Tags"].toUpperCase().indexOf(tag.toUpperCase()) !== -1) {
+                                                        agentApi.logDebug (`${addSpace(modeStack.length + 4)} Found match on tag`);
                                                         okToAdd = true;
                                                         break;
                                                     } else {
-                                                        agentApi.logDebug (`${addSpace(modeStack.length + 4)} Field does not exist`);
+                                                        agentApi.logDebug (`${addSpace(modeStack.length + 4)} No match on tag`);
                                                     }
-                                                } else if (wi.fields[parts[0]] !== undefined && wi.fields[parts[0]] === parts[1]) {
-                                                    agentApi.logDebug (`${addSpace(modeStack.length + 4)} Found match on field`);
-                                                    okToAdd = true;
-                                                    break;
-                                                } else {
-                                                    agentApi.logDebug (`${addSpace(modeStack.length + 4)} No match on field`);
+                                                }
+                                            } else {
+                                                agentApi.logDebug (`${addSpace(modeStack.length + 4)} No tags to check, checking fields`);
+                                            }
+                                            if (okToAdd === false) {
+                                                for (let field of wiFilter.fields) {
+                                                    parts = field.split("=");
+                                                    agentApi.logDebug (`${addSpace(modeStack.length + 4)} Comparing field '${parts[0]}' contents '${wi.fields[parts[0]]}' to '${parts[1]}'`);
+                                                    if (parts[1] === anyFieldContent) {
+                                                        agentApi.logDebug (`${addSpace(modeStack.length + 4)} The contents match is the 'any data value`);
+                                                        if (wi.fields[parts[0]] !== undefined) {
+                                                            agentApi.logDebug (`${addSpace(modeStack.length + 4)} Field exist`);
+                                                            okToAdd = true;
+                                                            break;
+                                                        } else {
+                                                            agentApi.logDebug (`${addSpace(modeStack.length + 4)} Field does not exist`);
+                                                        }
+                                                    } else if (wi.fields[parts[0]] !== undefined && wi.fields[parts[0]] === parts[1]) {
+                                                        agentApi.logDebug (`${addSpace(modeStack.length + 4)} Found match on field`);
+                                                        okToAdd = true;
+                                                        break;
+                                                    } else {
+                                                        agentApi.logDebug (`${addSpace(modeStack.length + 4)} No match on field`);
+                                                    }
                                                 }
                                             }
-                                        }
-                                        if (okToAdd) {
-                                            agentApi.logDebug (`${addSpace(modeStack.length + 4)} Adding WI ${wi.id} as at least one tag or field matches`);
-                                            modeArray.push(wi);
-                                        }
-                                        break;
-                                    default:
-                                        agentApi.logWarn (`${addSpace(modeStack.length + 4)} Invalid filter passed, skipping WI ${wi.id}`);
-                                }
-                            });
-                        } else {
-                            agentApi.logDebug (`${addSpace(modeStack.length + 4)} Adding all WI as no tag or fields filter`);
-                            modeArray = workItems;
-                        }
-                        agentApi.logDebug (`${addSpace(modeStack.length + 1)} There are ${modeArray.length} WI to add`);
-                        addStackItem (modeArray, modeStack, line, index);
-                        // now we have stack item we can get the first item
-                        if (modeStack[modeStack.length - 1].BlockQueue.length > 0) {
-                            widetail = modeStack[modeStack.length - 1].BlockQueue.shift();
-                            agentApi.logDebug (`${addSpace(modeStack.length + 1)} Getting first workitem ${widetail.id}`);
-                        } else {
-                            widetail = undefined;
-                        }
-                        break;
-                      case Mode.CS:
-                        var filterArray = [];
-                        if (csFilter.trim().length > 0) {
-                            var regexp = new RegExp(csFilter);
-                            agentApi.logDebug(`${addSpace(modeStack.length + 1)} Regex filter '${csFilter}' used to filter CS`);
-                            commits.forEach(cs => {
-                                if (cs.message.length > 0 ) {
-                                    agentApi.logDebug(`${addSpace(modeStack.length + 1)} Regex test against '${cs.message}'`);
-                                    if (regexp.test(cs.message)) {
-                                        agentApi.logDebug(`${addSpace(modeStack.length + 1)} Match found adding`);
-                                        filterArray.push(cs);
-                                    } else {
-                                        agentApi.logDebug(`${addSpace(modeStack.length + 1)} No match found, not adding`);
+                                            if (okToAdd) {
+                                                agentApi.logDebug (`${addSpace(modeStack.length + 4)} Adding WI ${wi.id} as at least one tag or field matches`);
+                                                modeArray.push(wi);
+                                            }
+                                            break;
+                                        default:
+                                            agentApi.logWarn (`${addSpace(modeStack.length + 4)} Invalid filter passed, skipping WI ${wi.id}`);
                                     }
-                                } else {
-                                    agentApi.logDebug(`${addSpace(modeStack.length + 1)} Cannot do regex test as empty commit message`);
-                                }
-                            });
-                            // store the block and load the first item
-                            agentApi.logDebug (`${addSpace(modeStack.length + 1)} There are ${filterArray.length} matched CS out of ${commits.length} to add`);
-                            addStackItem (filterArray, modeStack, line, index);
-                        } else {
-                            agentApi.logDebug(`${addSpace(modeStack.length + 1)} No regex filter used to filter CS`);
-                            // store the block and load the first item
-                            addStackItem (commits, modeStack, line, index);
-                        }
-                        // now we have stack item we can get the first item
-                        if (modeStack[modeStack.length - 1].BlockQueue.length > 0) {
-                             csdetail = modeStack[modeStack.length - 1].BlockQueue.shift();
-                             if (csdetail.type.toLowerCase() === "tfsgit") {
-                                // Git mode
-                                agentApi.logDebug (`${addSpace(modeStack.length + 1)} Getting first commit ${csdetail.id}`);
-                             } else {
-                                // TFVC mode
-                                agentApi.logDebug (`${addSpace(modeStack.length + 1)} Getting first changeset ${csdetail.id}`);
-                             }
-                        } else {
-                              csdetail = undefined;
-                        }
-                         break;
-                    } // end switch
-                }
-            } else {
-                // agentApi.logDebug(`${addSpace(modeStack.length + 1)} Mode != BODY`);
-                if ( line.trim().length === 0) {
-                    // we have a blank line, we can't eval this
-                    agentApi.logDebug(`${addSpace(modeStack.length + 1)} Outputing a blank line`);
-                    output += "\n";
-                } else {
-                    if (((getMode(modeStack[modeStack.length - 1].BlockMode) === Mode.WI) && (widetail === undefined)) ||
-                       ((getMode(modeStack[modeStack.length - 1].BlockMode) === Mode.CS) && (csdetail === undefined))) {
-                        // # there is no data to expand
-                        agentApi.logDebug(`${addSpace(modeStack.length + 1)} No WI or CS so outputing emptySetText`);
-                        output += emptySetText;
-                    } else {
-                        agentApi.logDebug(`${addSpace(modeStack.length + 1)} Nothing to expand, just process the line`);
-                        // nothing to expand just process the line
-                        var fixedline = fixline (line);
-                        var processedLine = eval(fixedline);
-                        var lines = processedLine.split("\r\n");
-                        for ( var i = 0; i < lines.length; i ++) {
-                            output += lines[i];
-                        }
+                                });
+                            } else {
+                                agentApi.logDebug (`${addSpace(modeStack.length + 4)} Adding all WI as no tag or fields filter`);
+                                modeArray = workItems;
+                            }
+                            agentApi.logDebug (`${addSpace(modeStack.length + 1)} There are ${modeArray.length} WI to add`);
+                            addStackItem (modeArray, modeStack, line, index);
+                            // now we have stack item we can get the first item
+                            if (modeStack[modeStack.length - 1].BlockQueue.length > 0) {
+                                widetail = modeStack[modeStack.length - 1].BlockQueue.shift();
+                                agentApi.logDebug (`${addSpace(modeStack.length + 1)} Getting first workitem ${widetail.id}`);
+                            } else {
+                                widetail = undefined;
+                            }
+                            break;
+                          case Mode.CS:
+                            var filterArray = [];
+                            if (csFilter.trim().length > 0) {
+                                var regexp = new RegExp(csFilter);
+                                agentApi.logDebug(`${addSpace(modeStack.length + 1)} Regex filter '${csFilter}' used to filter CS`);
+                                commits.forEach(cs => {
+                                    if (cs.message.length > 0 ) {
+                                        agentApi.logDebug(`${addSpace(modeStack.length + 1)} Regex test against '${cs.message}'`);
+                                        if (regexp.test(cs.message)) {
+                                            agentApi.logDebug(`${addSpace(modeStack.length + 1)} Match found adding`);
+                                            filterArray.push(cs);
+                                        } else {
+                                            agentApi.logDebug(`${addSpace(modeStack.length + 1)} No match found, not adding`);
+                                        }
+                                    } else {
+                                        agentApi.logDebug(`${addSpace(modeStack.length + 1)} Cannot do regex test as empty commit message`);
+                                    }
+                                });
+                                // store the block and load the first item
+                                agentApi.logDebug (`${addSpace(modeStack.length + 1)} There are ${filterArray.length} matched CS out of ${commits.length} to add`);
+                                addStackItem (filterArray, modeStack, line, index);
+                            } else {
+                                agentApi.logDebug(`${addSpace(modeStack.length + 1)} No regex filter used to filter CS`);
+                                // store the block and load the first item
+                                addStackItem (commits, modeStack, line, index);
+                            }
+                            // now we have stack item we can get the first item
+                            if (modeStack[modeStack.length - 1].BlockQueue.length > 0) {
+                                 csdetail = modeStack[modeStack.length - 1].BlockQueue.shift();
+                                 if (csdetail.type.toLowerCase() === "tfsgit") {
+                                    // Git mode
+                                    agentApi.logDebug (`${addSpace(modeStack.length + 1)} Getting first commit ${csdetail.id}`);
+                                 } else {
+                                    // TFVC mode
+                                    agentApi.logDebug (`${addSpace(modeStack.length + 1)} Getting first changeset ${csdetail.id}`);
+                                 }
+                            } else {
+                                  csdetail = undefined;
+                            }
+                             break;
+                        } // end switch
                     }
-                    // always add a line feed
-                    output += "\n";
+                } else {
+                    // agentApi.logDebug(`${addSpace(modeStack.length + 1)} Mode != BODY`);
+                    if ( line.trim().length === 0) {
+                        // we have a blank line, we can't eval this
+                        agentApi.logDebug(`${addSpace(modeStack.length + 1)} Outputing a blank line`);
+                        output += "\n";
+                    } else {
+                        if (((getMode(modeStack[modeStack.length - 1].BlockMode) === Mode.WI) && (widetail === undefined)) ||
+                           ((getMode(modeStack[modeStack.length - 1].BlockMode) === Mode.CS) && (csdetail === undefined))) {
+                            // # there is no data to expand
+                            agentApi.logDebug(`${addSpace(modeStack.length + 1)} No WI or CS so outputing emptySetText`);
+                            output += emptySetText;
+                        } else {
+                            agentApi.logDebug(`${addSpace(modeStack.length + 1)} Nothing to expand, just process the line`);
+                            // nothing to expand just process the line
+                            var fixedline = fixline (line);
+                            var processedLine = eval(fixedline);
+                            var lines = processedLine.split("\r\n");
+                            for ( var i = 0; i < lines.length; i ++) {
+                                output += lines[i];
+                            }
+                        }
+                        // always add a line feed
+                        output += "\n";
+                    }
                 }
-            }
-        }  // loop
+            }  // loop
+        }
+        else {
+            // it is a handlebar template
+            agentApi.logDebug("Processing handlebar template");
+
+            // compile the template
+            var handlebarsTemplate = Handlebars.compile(template);
+            // execute the compiled template
+            output = handlebarsTemplate({ "workItems": workItems, "buildDetails": buildDetails, "releaseDetails": releaseDetails, "compareReleaseDetails": compareReleaseDetails });
+        }    
         agentApi.logInfo( "Completed processing template");
     } else {
         agentApi.logError( `Cannot load template file [${template}] or it is empty`);

--- a/Extensions/XplatGenerateReleaseNotes/V2/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V2/ReleaseNotesFunctions.ts
@@ -153,7 +153,7 @@ export function getTemplate(
     ): Array<string> {
         agentApi.logDebug(`Using template mode ${templateLocation}`);
         var template;
-        const handlebarIndicator = '{{';
+        const handlebarIndicator = "{{";
         if (templateLocation === "File") {
             agentApi.logInfo (`Loading template file ${templatefile}`);
             template = fs.readFileSync(templatefile).toString();
@@ -431,16 +431,15 @@ export function processTemplate(template, workItems: WorkItem[], commits: Change
                     }
                 }
             }  // loop
-        }
-        else {
+        } else {
             // it is a handlebar template
             agentApi.logDebug("Processing handlebar template");
 
             // compile the template
             var handlebarsTemplate = Handlebars.compile(template);
             // execute the compiled template
-            output = handlebarsTemplate({ "workItems": workItems, "buildDetails": buildDetails, "releaseDetails": releaseDetails, "compareReleaseDetails": compareReleaseDetails });
-        }    
+            output = handlebarsTemplate({ "workItems": workItems, "commits": commits, "buildDetails": buildDetails, "releaseDetails": releaseDetails, "compareReleaseDetails": compareReleaseDetails });
+        }
         agentApi.logInfo( "Completed processing template");
     } else {
         agentApi.logError( `Cannot load template file [${template}] or it is empty`);

--- a/Extensions/XplatGenerateReleaseNotes/V2/package-lock.json
+++ b/Extensions/XplatGenerateReleaseNotes/V2/package-lock.json
@@ -1057,6 +1057,17 @@
             "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
             "dev": true
         },
+        "handlebars": {
+            "version": "4.7.3",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
+            "integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
+            "requires": {
+                "neo-async": "^2.6.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.1.4"
+            }
+        },
         "har-schema": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -1825,6 +1836,11 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
             "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
+        },
+        "neo-async": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+            "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
         },
         "nested-error-stacks": {
             "version": "1.0.2",
@@ -4528,6 +4544,27 @@
             "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
             "dev": true
         },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "requires": {
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.10",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                    "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+                },
+                "wordwrap": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+                }
+            }
+        },
         "os-homedir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -4991,8 +5028,7 @@
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "source-map-support": {
             "version": "0.5.4",
@@ -5861,6 +5897,24 @@
                     "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
                     "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
                     "dev": true
+                }
+            }
+        },
+        "uglify-js": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
+            "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
+            "optional": true,
+            "requires": {
+                "commander": "~2.20.3",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.20.3",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                    "optional": true
                 }
             }
         },

--- a/Extensions/XplatGenerateReleaseNotes/V2/package.json
+++ b/Extensions/XplatGenerateReleaseNotes/V2/package.json
@@ -14,6 +14,7 @@
     "@types/q": "^1.5.1",
     "@types/xmldom": "^0.1.29",
     "fs": "^0.0.1-security",
+    "handlebars": "^4.7.3",
     "ncp": "^2.0.0",
     "request": "^2.88.0",
     "tsd": "^0.6.5",

--- a/Extensions/XplatGenerateReleaseNotes/package-lock.json
+++ b/Extensions/XplatGenerateReleaseNotes/package-lock.json
@@ -179,6 +179,17 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
+        "handlebars": {
+            "version": "4.7.3",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
+            "integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
+            "requires": {
+                "neo-async": "^2.6.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.1.4"
+            }
+        },
         "has-ansi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -253,6 +264,11 @@
             "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
             "dev": true
         },
+        "neo-async": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+            "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -260,6 +276,22 @@
             "dev": true,
             "requires": {
                 "wrappy": "1"
+            }
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "requires": {
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.10",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                    "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+                }
             }
         },
         "path": {
@@ -334,6 +366,11 @@
                 "rechoir": "^0.6.2"
             }
         },
+        "source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -396,6 +433,24 @@
             "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
             "dev": true
         },
+        "uglify-js": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
+            "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
+            "optional": true,
+            "requires": {
+                "commander": "~2.20.3",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.20.3",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                    "optional": true
+                }
+            }
+        },
         "util": {
             "version": "0.10.3",
             "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
@@ -418,6 +473,11 @@
             "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
             "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA==",
             "dev": true
+        },
+        "wordwrap": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         },
         "wrappy": {
             "version": "1.0.2",

--- a/Extensions/XplatGenerateReleaseNotes/package.json
+++ b/Extensions/XplatGenerateReleaseNotes/package.json
@@ -18,6 +18,7 @@
         "validator": "^9.4.1"
     },
     "dependencies": {
-        "child_process": "^1.0.2"
+        "child_process": "^1.0.2",
+        "handlebars": "^4.7.3"
     }
 }

--- a/SampleTemplates/XplatGenerateReleaseNotes (Node based)/Version 2/release-handlebars-template.md
+++ b/SampleTemplates/XplatGenerateReleaseNotes (Node based)/Version 2/release-handlebars-template.md
@@ -1,0 +1,20 @@
+## Notes for release  {{releaseDetails.releaseDefinition.name}}    
+**Release Number**  : {{releaseDetails.name}}
+**Release completed** : {{releaseDetails.modifiedOn}}     
+**Build Number**: {{buildDetails.id}}
+**Compared Release Number**  : {{compareReleaseDetails.name}}    
+
+### Associated Work Items ({{workItems.length}})
+
+{{#each workItems}}
+*  **{{this.id}}**  {{lookup this.fields 'System.Title'}}
+   - **WIT** {{lookup this.fields 'System.WorkItemType'}} 
+   - **Tags** {{lookup this.fields 'System.Tags'}}
+{{/each}}
+
+### Associated commits ({{commits.length}})
+{{#each commits}}
+* ** ID{{this.id}}** 
+   -  **Message:** {{this.message}}
+   -  **Commited by:** {{this.author.displayName}} 
+{{/each}}


### PR DESCRIPTION
### What problem does this PR address?
Existing template capabilities are limited.  Enabling use of a library such as Handlebars gives the user much more power and flexibility over the rendered markup.
  
### Is there a related Issue?
N/A
  
Please take a look at my proposed change to allow Handlebars templates.  I think it's a pretty simple change that would greatly enhance the extension.   Please note that I do not have a way to test this, so while I tried to be as careful as possible with the code, it's ultimately more of a proposal for changes than a guarantee of the working change.

Because I tabbed everything over when wrapped the guts of the processTemplate in an IF statement, the diff looks pretty ugly - but in a nutshell, all I really did was the following:
1) added the npm handlebars package
2) modified the getTemplate function to detect a handlebar template by checking for "{{".  If one is found, the template in its entirety is returned (not processed into an array).
3) modified the processTemplate function to detect a handlebar template by checking for an array (the handlebars templates will be a single string).  I then wrapped the guts of the method in an IF statement so that if the handlebar template is not found, processing continues as expected. If one is found, it compiles the template and passes the relevant objects in on the execution.

Please check it out and let me know what you think.  I gave you access to the fork.

Thanks for considering this!


