### PR TITLE
Handle gallery failure by falling back to shipped version of pester

### DIFF
--- a/Extensions/Pester/task/Pester.ps1
+++ b/Extensions/Pester/task/Pester.ps1
@@ -85,7 +85,13 @@ if ((Get-Module -Name PowerShellGet -ListAvailable) -and
     }
     $NewestPester = Find-Module -Name Pester | Sort-Object Version -Descending | Select-Object -First 1
     If ((Get-Module Pester -ListAvailable | Sort-Object Version -Descending| Select-Object -First 1).Version -lt $NewestPester.Version) {
-        Install-Module -Name Pester -Scope CurrentUser -Force -Repository $NewestPester.Repository -SkipPublisherCheck
+        try {
+            Install-Module -Name Pester -Scope CurrentUser -Force -Repository $NewestPester.Repository -SkipPublisherCheck -MaximumVersion 4.99.99 -ErrorAction Stop
+        }
+        catch {
+            Write-Host "##vos[task.logissue type=warning]There was an issue downloading a new version of Pester so falling back to version of Pester shipped with extension."
+            Import-Module "$PSScriptRoot\4.6.0\Pester.psd1" -force
+        }
     }
     Import-Module -Name Pester
 }

--- a/Extensions/Pester/vss-extension.json
+++ b/Extensions/Pester/vss-extension.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/rfennell/AzurePipelines/issues"
   }, 
    "categories": [
-    "Build and release"
+    "Azure Pipelines"
   ],
   "targets": [
     {


### PR DESCRIPTION
### What problem does this PR address?
Pester. Handles failures downloading from the gallery (whichever gallery that might be).
  
### Is there a related Issue?
#677 and #507 
  
### Have you...
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
