### PR TITLE
Exposed a way to inject a PAT

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/V3/GenerateReleaseNotes.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V3/GenerateReleaseNotes.ts
@@ -37,9 +37,10 @@ async function run(): Promise<number>  {
             var checkStage = tl.getBoolInput("checkStage");
             var getAllParents = tl.getBoolInput("getAllParents");
             var tags = tl.getInput("tags");
+            var overridePat = tl.getInput("overridePat");
 
             var returnCode = await util.generateReleaseNotes(
-                "",
+                overridePat,
                 tpcUri,
                 teamProject,
                 parseInt(tl.getVariable("Build.BuildId")),

--- a/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
@@ -315,7 +315,7 @@ export function getCredentialHandler(pat: string): IRequestHandler {
         }
         return credHandler;
     } else {
-        tl.debug("Using PAT (suitable for local test only)");
+        tl.debug("Using override PAT (suitable for local testing or if the OUATH token cannot be used)");
         return webApi.getPersonalAccessTokenHandler(pat);
     }
 

--- a/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
@@ -303,19 +303,19 @@ export async function enrichChangesWithFileDetails(
 export function getCredentialHandler(pat: string): IRequestHandler {
     if (!pat || pat.length === 0) {
         // no pat passed so we need the system token
-        tl.debug("Getting System.AccessToken");
+        agentApi.logDebug("Getting System.AccessToken");
         var accessToken = agentApi.getSystemAccessToken();
         let credHandler: IRequestHandler;
         if (!accessToken || accessToken.length === 0) {
             throw "Unable to locate access token that will allow access to Azure DevOps API.";
         } else {
-            tl.debug("Creating the credential handler");
+            agentApi.logInfo("Creating the credential handler from the OAUTH token");
             // used for local debugging.  Allows switching between PAT token and Bearer Token for debugging
             credHandler = webApi.getHandlerFromToken(accessToken);
         }
         return credHandler;
     } else {
-        tl.debug("Using override PAT (suitable for local testing or if the OUATH token cannot be used)");
+        agentApi.logInfo("Creating the credential handler using override PAT (suitable for local testing or if the OAUTH token cannot be used)");
         return webApi.getPersonalAccessTokenHandler(pat);
     }
 

--- a/Extensions/XplatGenerateReleaseNotes/V3/task.json
+++ b/Extensions/XplatGenerateReleaseNotes/V3/task.json
@@ -264,6 +264,15 @@
       "required": false,
       "helpMarkDown": "A comma separated list of pipeline tags that must all be matched when looking for previous successful builds, only used if checkStage=true",
       "groupName":"advanced"
+    },
+    {
+      "name": "overridePat",
+      "type": "string",
+      "label": "Override Pat",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "It is possible to inject a Personal Access Token to use in place of the Build Agent OAUTH token. This option will only be used in very rare situations usually after a support issue has been raise",
+      "groupName":"advanced"
     }
 
 

--- a/Extensions/XplatGenerateReleaseNotes/V3/task.json
+++ b/Extensions/XplatGenerateReleaseNotes/V3/task.json
@@ -271,7 +271,7 @@
       "label": "Override Pat",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "It is possible to inject a Personal Access Token to use in place of the Build Agent OAUTH token. This option will only be used in very rare situations usually after a support issue has been raise",
+      "helpMarkDown": "It is possible to inject a Personal Access Token to use in place of the Build Agent OAUTH token. This option will only be used in very rare situations usually after a support issue has been raised",
       "groupName":"advanced"
     }
 

--- a/Extensions/XplatGenerateReleaseNotes/readme.md
+++ b/Extensions/XplatGenerateReleaseNotes/readme.md
@@ -203,6 +203,7 @@ The task takes the following parameters
 * (Advanced) Get Direct Parent and Children for associated work items, defaults to false
 * (Advanced) Get All Parents for associated work items, recursing back to workitem with no parents e.g. up to Epics, defaults to false
 * (Advanced) Tags a comma separated list of pipeline tags that must all be matched when looking for previous successful builds , only used if checkStage=true
+* (Advanced) overridePat a means to inject a Personal Access Token to use in place of the Build Agent OAUTH token. This option will only be used in very rare situations usually after a support issue has been raised, defaults to empty
 * (Handlebars) customHandlebars ExtensionCode. A custom Handlebars extension written as a JavaScript module e.g. module.exports = {foo: function () {return 'Returns foo';}};
 * (Outputs) Optional: Name of the variable that release notes contents will be copied into for use in other tasks. As an output variable equates to an environment variable, so there is a limit on the maximum size. For larger release notes it is best to save the file locally as opposed to using an output variable.
 


### PR DESCRIPTION
#801 

Provides a means to inject a Personal Access Token to use in place of the Build Agent OAUTH token. This option will only be used in very rare situations usually after a support issue has been raised