### PR TITLE
Split the error handling so release note generation always attempted even with API errors

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
@@ -905,10 +905,12 @@ export async function generateReleaseNotes(
             var globalBuilds: UnifiedArtifactDetails[] = [];
             var globalTests: TestCaseResult[] = [];
             var releaseTests: TestCaseResult[] = [];
+            var relatedWorkItems: WorkItem[] = [];
+            var fullWorkItems: WorkItem[] = [];
 
             var mostRecentSuccessfulDeploymentName: string = "";
-            let mostRecentSuccessfulDeploymentRelease: Release;
-            let mostRecentSuccessfulBuild: Build;
+            var mostRecentSuccessfulDeploymentRelease: Release;
+            var mostRecentSuccessfulBuild: Build;
 
             var currentRelease: Release;
             var currentBuild: Build;
@@ -1188,9 +1190,7 @@ export async function generateReleaseNotes(
             }
 
             // get an array of workitem ids
-            let fullWorkItems = await getFullWorkItemDetails(workItemTrackingApi, globalWorkItems);
-
-            let relatedWorkItems = [];
+            fullWorkItems = await getFullWorkItemDetails(workItemTrackingApi, globalWorkItems);
 
             if (getParentsAndChildren) {
                 agentApi.logInfo("Getting direct parents and children of WorkItems");
@@ -1304,6 +1304,14 @@ export async function generateReleaseNotes(
                 // enrich the founds PRs
                 await enrichPullRequest(gitApi, inDirectlyAssociatedPullRequests);
             }
+
+        } catch (ex) {
+            agentApi.logInfo(`The most common reason for the task to fail is due API ECONNRESET issues. To avoid this failing the pipeline these will be treated as warnings and an attempt to generate any release notes possible`);
+            agentApi.logWarn(ex);
+            reject (ex);
+        }
+
+        try {
             agentApi.logInfo(`Total Builds: [${globalBuilds.length}]`);
             agentApi.logInfo(`Total Commits: [${globalCommits.length}]`);
             agentApi.logInfo(`Total Workitems: [${globalWorkItems.length}]`);

--- a/Extensions/XplatGenerateReleaseNotes/readme.md
+++ b/Extensions/XplatGenerateReleaseNotes/readme.md
@@ -344,7 +344,7 @@ Error: connect ETIMEDOUT 13.107.42.18:443
 
 This is an issue with the underlying Azure DevOps Node SDK or REST API endpoints, not this task. Hence, an issue has been raised in the the appropriate [Repo #425](https://github.com/microsoft/azure-devops-node-api/issues/425)
 
-The best workaround at present is to always place this task, and any associated tasks e.g. one that upload the generated release notes to a WIKI, in a dedicated YML pipeline job. This allows the task to be easily retried without rerunning the whole pipeline.
+Historically the only workaround has been to always place this task, and any associated tasks e.g. one that upload the generated release notes to a WIKI, in a dedicated YML pipeline job. This allows the task to be easily retried without rerunning the whole pipeline. However, with 3.37.x the error traps have been changed in the task to treat any error that occurs whilst accessing the API as a warning, but allow the task to run on to try to generate any release notes it can with the data it has managed to get. This is far from perfect but a bit more robust.
 
 ## OAUTH Scope limiting what Associated Items can be seen
 This task uses the build agent's access OAUTH token to access the Azure DevOps API. The permissions this identity has is dependant upon the [the Job authorization scope](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/access-tokens?view=azure-devops&tabs=yaml#job-authorization-scope).


### PR DESCRIPTION
#648