### PR TITLE
Support build info restoring when using Pipeline Artifacts

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
@@ -1113,29 +1113,29 @@ export async function generateReleaseNotes(
                 let isInitialRelease = false;
 
                 agentApi.logInfo(`Getting all artifacts in the current release...`);
-                var arifactsInThisRelease = getSimpleArtifactArray(currentRelease.artifacts);
-                buildId = await restoreAzurePipelineArtifactsBuildInfo(arifactsInThisRelease, organisation) || buildId; // update build id if using pipeline artifacts
-                agentApi.logInfo(`Found ${arifactsInThisRelease.length}`);
+                var artifactsInThisRelease = getSimpleArtifactArray(currentRelease.artifacts);
+                buildId = await restoreAzurePipelineArtifactsBuildInfo(artifactsInThisRelease, organisation) || buildId; // update build id if using pipeline artifacts
+                agentApi.logInfo(`Found ${artifactsInThisRelease.length}`);
 
-                let arifactsInMostRecentRelease: SimpleArtifact[] = [];
+                let artifactsInMostRecentRelease: SimpleArtifact[] = [];
                 if (mostRecentSuccessfulDeployment) {
                     // Get the release that the deployment was a part of - This is required for the templating.
                     mostRecentSuccessfulDeploymentRelease = await releaseApi.getRelease(teamProject, mostRecentSuccessfulDeployment.release.id);
                     agentApi.logInfo(`Getting all artifacts in the most recent successful release [${mostRecentSuccessfulDeployment.release.name}]...`);
-                    arifactsInMostRecentRelease = getSimpleArtifactArray(mostRecentSuccessfulDeployment.release.artifacts);
-                    await restoreAzurePipelineArtifactsBuildInfo(arifactsInMostRecentRelease, organisation);
+                    artifactsInMostRecentRelease = getSimpleArtifactArray(mostRecentSuccessfulDeployment.release.artifacts);
+                    await restoreAzurePipelineArtifactsBuildInfo(artifactsInMostRecentRelease, organisation);
                     mostRecentSuccessfulDeploymentName = mostRecentSuccessfulDeployment.release.name;
-                    agentApi.logInfo(`Found ${arifactsInMostRecentRelease.length}`);
+                    agentApi.logInfo(`Found ${artifactsInMostRecentRelease.length}`);
                 } else {
                     agentApi.logInfo(`Skipping fetching artifact in the most recent successful release as there isn't one.`);
                     // we need to set the last successful as the current release to templates can get some data
                     mostRecentSuccessfulDeploymentRelease = currentRelease;
                     mostRecentSuccessfulDeploymentName = "Initial Deployment";
-                    arifactsInMostRecentRelease = arifactsInThisRelease;
+                    artifactsInMostRecentRelease = artifactsInThisRelease;
                     isInitialRelease = true;
                 }
 
-                for (var artifactInThisRelease of arifactsInThisRelease) {
+                for (var artifactInThisRelease of artifactsInThisRelease) {
                     agentApi.logInfo(`Looking at artifact [${artifactInThisRelease.artifactAlias}]`);
                     agentApi.logInfo(`Artifact type [${artifactInThisRelease.artifactType}]`);
                     agentApi.logInfo(`Build Definition ID [${artifactInThisRelease.buildDefinitionId}]`);
@@ -1143,10 +1143,10 @@ export async function generateReleaseNotes(
                     agentApi.logInfo(`Is Primary: [${artifactInThisRelease.isPrimary}]`);
 
                     if ((showOnlyPrimary === false) || (showOnlyPrimary === true && artifactInThisRelease.isPrimary === true)) {
-                        if (arifactsInMostRecentRelease.length > 0) {
+                        if (artifactsInMostRecentRelease.length > 0) {
                             if (artifactInThisRelease.artifactType === "Build") {
                                 agentApi.logInfo(`Looking for the [${artifactInThisRelease.artifactAlias}] in the most recent successful release [${mostRecentSuccessfulDeploymentName}]`);
-                                for (var artifactInMostRecentRelease of arifactsInMostRecentRelease) {
+                                for (var artifactInMostRecentRelease of artifactsInMostRecentRelease) {
                                     if (artifactInThisRelease.artifactAlias.toLowerCase() === artifactInMostRecentRelease.artifactAlias.toLowerCase()) {
                                         agentApi.logInfo(`Found artifact [${artifactInMostRecentRelease.artifactAlias}] with build number [${artifactInMostRecentRelease.buildNumber}] in release [${mostRecentSuccessfulDeploymentName}]`);
 


### PR DESCRIPTION
### What problem does this PR address?
We're trying to migrate our things to store from `Build Artifacts` to `Pipeline Artifacts` (`Universal packages` actually) for better permission control, see [Overview of Artifacts in Azure Pipelines](https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/artifacts-overview?view=azure-devops).
However, as of XplatGenerateReleaseNotes@3.42.2, the [`artifactInThisRelease.artifactType === "Build"`](https://github.com/rfennell/AzurePipelines/blob/XplatGenerateReleaseNotes_3.42.2/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts#L1069-L1169) is checked before getting build info from CI pipeline, which make the Pipeline Artifacts be bypassed with **no commit and work item info**.

I'm not trying to change those logic, but instead, to "hack" and restore the original build pipeline info before getting into those parts with the introduced function [`restoreAzurePipelineArtifactsBuildInfo(artifactsInRelease: SimpleArtifact[], webApi: WebApi)`](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583R129).

> Use the `Azure Artifact` [(artifactType === "PackageManagement")](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583R132) instead of `Build` as release source
> * 【AS-IS】Build Pipeline > **Build Artifacts** >>> Release Source (***Build***) > *Generate Release Notes*
> * 【TO-BE】Build Pipeline > Pipeline Artifacts (**Universal Packages**) >>> Release Source (***Azure Artifacts*** / PackageManagement) > **RESTORE Original Build Info** (buildId, buildDefId, etc.) > *Generate Release Notes*
> <img src="https://user-images.githubusercontent.com/37973545/106455827-af76cc80-64c7-11eb-84cd-a01f45ee35ec.png" width=600/>


### Implementation
0. **Main logic of this PR**: To [`restore build info`](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583R183-R200) for [i. `artifactsInThisRelease`](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583R1117) and [ii. `artifactsInMostRecentRelease `](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583R1126).

1. The actual tricky I do is to [extract the projectId and feedId](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583R183-R185) for the [`Artifact Details - Get Package`](https://docs.microsoft.com/en-us/rest/api/azure/devops/artifacts/artifact%20%20details/get%20package?view=azure-devops-rest-6.0) API to get the [versionId](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583R188).
And then use those ids to [get the original build pipeline info](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583R189-R196) with [`Artifact Details - Get Package Version Provenance`](https://docs.microsoft.com/en-us/rest/api/azure/devops/artifacts/artifact%20%20details/getpackageversionprovenance?view=azure-devops-rest-6.0) API.

2. The [`packageVersionId `](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583R187-R188) is got by setting the [`includeAllVersions`](https://docs.microsoft.com/en-us/rest/api/azure/devops/artifacts/artifact%20%20details/get%20package?view=azure-devops-rest-6.0) as TRUE (which is false by default) to query all versions and then [find with matching `version.normalizedVersion === packageVersion`](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583R188).

3. There are two places that require the restoring, including the [`arifactsInThisRelease `](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583L1040-R1117) and [`arifactsInMostRecentRelease`](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583R1125-R1126), while the former one also NEEDS to update the `buildId` as well for the later usages.

### Notes
0. This PR works well for our cases, but I think there are no test cases for this feature now, so I'm not sure if it's a good idea or a good time to accept this PR.
1. I'm not sure if the `version.normalizedVersion === packageVersion` I used for checking the version should use **`normalizedVersion`** or just **`version`** because they are the same string in this case; however, as the document mentioned, the `version` stands for *Display version* and might not be a unique one or what.
2. As of [`azure-devops-node-api@10.2.1`](https://github.com/microsoft/azure-devops-node-api/tree/470f9ca7bdfccd87e1c1fdea8023b8c3d2b1047a/api), the **`PackagingApi`** (or maybe the [**`FeedApi`** in Python](https://github.com/microsoft/azure-devops-python-api/blob/6.0.0b4/azure-devops/azure/devops/v6_0/feed/feed_client.py#L325-L503)) is not yet be supported; therefore, I have to [handcraft one](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583R134-R182) (marked as **`FIXME #937`**).
3. In order to handcraft a Packaging API, [two imports are added in need](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583R44-R45), which should also be **removed** when the SDK provides an available API.
4. As the `2.` says, the entry point for Azure DevOps API is called `Packaging` by Microsoft but the one used in Python SDK is called `Feed`, which is not yet exists in Node's SDK; therefore, the naming may change when available.
5. The location Id [`"7a20d846-c929-4acc-9ea2-0d5a7df1b197"` for `getPackage()`](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583R149) and the [`"0aaeabd4-85cd-4686-8a77-8d31c15690b8"` for `getPackageVersionProvenance()`](https://github.com/rfennell/AzurePipelines/pull/937/files#diff-e50c4715a7aff1d81e85b9ce18a00731b8257b315955584f1d033a53e6233583R166) could be got via ***EITHER***:
    a. The functions  [`get_package()`](https://github.com/microsoft/azure-devops-python-api/blob/6.0.0b4/azure-devops/azure/devops/v6_0/feed/feed_client.py#L360) and [`get_package_version_provenance()`](https://github.com/microsoft/azure-devops-python-api/blob/6.0.0b4/azure-devops/azure/devops/v6_0/feed/feed_client.py#L500) provided in Python's feed_client , ***OR***
    b. **`GET /resourceAreas`** and then **`OPTIONS /Packaging`**, e.g., *`curl https://dev.azure.com/LouisSung-Demo/_apis/resourceAreas`* followed by *`curl -X OPTIONS https://feeds.dev.azure.com/LouisSung-Demo/_apis/Packaging`*