### PR TITLE
Use adequate status when looking for partially succeeded deployments

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
@@ -269,7 +269,7 @@ export async function getMostRecentSuccessfulDeployment(
 
             if (considerPartiallySuccessfulReleases === true) {
                 agentApi.logInfo (`Finding partially successful deployments`);
-                var partialSuccessfulDeployments = await releaseApi.getDeployments(teamProject, releaseDefinitionId, environmentId, null, null, null, DeploymentStatus.Failed, null, true, null, null, null, null).catch((reason) => {
+                var partialSuccessfulDeployments = await releaseApi.getDeployments(teamProject, releaseDefinitionId, environmentId, null, null, null, DeploymentStatus.PartiallySucceeded, null, true, null, null, null, null).catch((reason) => {
                     reject(reason);
                     return;
                 });


### PR DESCRIPTION
### What problem does this PR address?
Enabling the option `Consider Partially Successful Release`, does not find partially succeeded deployments.
