### PR TITLE
#1176: gaurding against null record.result

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
@@ -1152,7 +1152,7 @@ export async function getLastSuccessfulBuildByStage(
                                 if (record.type === "Stage") {
                                     if (record.name === stageName || record.identifier === stageName) {
                                         agentApi.logInfo (`Found required stage ${record.name} in the state ${record.state.toString()} with the result ${record.result?.toString()} state for build ${build.id}`);
-                                        // checking enum values against 
+                                        // checking enum values against
                                         // https://docs.microsoft.com/en-us/dotnet/api/microsoft.teamfoundation.distributedtask.webapi.timelinerecordstate?view=azure-devops-dotnet
                                         // https://docs.microsoft.com/en-us/dotnet/api/microsoft.teamfoundation.distributedtask.webapi.taskresult?view=azure-devops-dotnet
                                         if ((record.state.toString() === "2" || record.state.toString() === "completed") && // completed

--- a/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
@@ -1151,8 +1151,8 @@ export async function getLastSuccessfulBuildByStage(
                                 const record  = timeline.records[timelineIndex];
                                 if (record.type === "Stage") {
                                     if (record.name === stageName || record.identifier === stageName) {
-                                        agentApi.logInfo (`Found required stage ${record.name} in the state ${record.state.toString()} with the result ${record.result.toString()} state for build ${build.id}`);
-                                        // checking enum values against https://docs.microsoft.com/en-us/dotnet/api/microsoft.teamfoundation.distributedtask.webapi.taskresult?view=azure-devops-dotnet
+                                        agentApi.logInfo (`Found required stage ${record.name} in the state ${record.state.toString()} with the result ${record.result?.toString()} state for build ${build.id}`);
+                                        // checking enum values against https://docs.microsoft.com/en-us/dotnet/api/microsoft.teamfoundation.distributedtask.webapi.timelinerecordstate?view=azure-devops-dotnet
                                         if ((record.state.toString() === "2" || record.state.toString() === "completed") && // completed
                                         (
                                             (considerPartiallySuccessfulReleases === false && (record.result.toString() === "0" || record.result.toString().toLowerCase() === "succeeded")) ||

--- a/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
@@ -1152,7 +1152,9 @@ export async function getLastSuccessfulBuildByStage(
                                 if (record.type === "Stage") {
                                     if (record.name === stageName || record.identifier === stageName) {
                                         agentApi.logInfo (`Found required stage ${record.name} in the state ${record.state.toString()} with the result ${record.result?.toString()} state for build ${build.id}`);
-                                        // checking enum values against https://docs.microsoft.com/en-us/dotnet/api/microsoft.teamfoundation.distributedtask.webapi.timelinerecordstate?view=azure-devops-dotnet
+                                        // checking enum values against 
+                                        // https://docs.microsoft.com/en-us/dotnet/api/microsoft.teamfoundation.distributedtask.webapi.timelinerecordstate?view=azure-devops-dotnet
+                                        // https://docs.microsoft.com/en-us/dotnet/api/microsoft.teamfoundation.distributedtask.webapi.taskresult?view=azure-devops-dotnet
                                         if ((record.state.toString() === "2" || record.state.toString() === "completed") && // completed
                                         (
                                             (considerPartiallySuccessfulReleases === false && (record.result.toString() === "0" || record.result.toString().toLowerCase() === "succeeded")) ||


### PR DESCRIPTION
Azure DevOps Extensions - Generate Release Notes (Node Cross Platform)

Adding a null check for record.result

#1176: TypeError: Cannot read properties of null (reading 'toString') 
