### PR TITLE
Revise handling of injectversion for Android and Angular versioner tasks

### DIFF
--- a/Extensions/Versioning/VersionAndroidManifest/src/ApplyVersionToManifest.ts
+++ b/Extensions/Versioning/VersionAndroidManifest/src/ApplyVersionToManifest.ts
@@ -43,12 +43,12 @@ console.log (`Found ${files.length} files to update.`);
 const newVersion = extractVersion(injectversion, versionRegex, versionNumber);
 console.log (`Extracted Version: ${newVersion}`);
 
-const versionName = getSplitVersionParts(versionRegex, versionNameFormat, newVersion);
+const versionName = getSplitVersionParts(injectversion, versionRegex, versionNameFormat, newVersion);
 console.log (`Version Name will be: ${versionName}`);
 
 if (injectversioncode === false) {
     console.log(`Building the version code from the build number`);
-    versionCode = getSplitVersionParts(versionRegex, versionCodeFormat, newVersion);
+    versionCode = getSplitVersionParts(injectversion, versionRegex, versionCodeFormat, newVersion);
 } else {
     console.log(`Using the injected version code`);
 }

--- a/Extensions/Versioning/VersionAndroidManifest/src/ApplyVersionToManifest.ts
+++ b/Extensions/Versioning/VersionAndroidManifest/src/ApplyVersionToManifest.ts
@@ -48,7 +48,7 @@ console.log (`Version Name will be: ${versionName}`);
 
 if (injectversioncode === false) {
     console.log(`Building the version code from the build number`);
-    versionCode = getSplitVersionParts(injectversion, versionRegex, versionCodeFormat, newVersion);
+    versionCode = getSplitVersionParts(injectversioncode, versionRegex, versionCodeFormat, newVersion);
 } else {
     console.log(`Using the injected version code`);
 }

--- a/Extensions/Versioning/VersionAndroidManifest/src/ApplyVersionToManifestFunctions.ts
+++ b/Extensions/Versioning/VersionAndroidManifest/src/ApplyVersionToManifestFunctions.ts
@@ -32,11 +32,14 @@ export function extractVersion(injectversion, versionRegex, versionNumber ) {
     return newVersion;
 }
 
-export function getSplitVersionParts (buildNumberFormat, outputFormat, version) {
-    const versionNumberSplitItems = version.split(extractDelimitersRegex(buildNumberFormat));
-    const versionNumberMatches = outputFormat.match(/\d/g);
-    const joinChar =  extractJoinChar(outputFormat);
-    const versionName = (versionNumberMatches.map((item) => versionNumberSplitItems[item - 1])).join(joinChar);
+export function getSplitVersionParts (injectversion, buildNumberFormat, outputFormat, version) {
+    var versionName = version;
+    if (injectversion === false) {
+        const versionNumberSplitItems = version.split(extractDelimitersRegex(buildNumberFormat));
+        const versionNumberMatches = outputFormat.match(/\d/g);
+        const joinChar =  extractJoinChar(outputFormat);
+        versionName = (versionNumberMatches.map((item) => versionNumberSplitItems[item - 1])).join(joinChar);
+        }
     return versionName;
 }
 

--- a/Extensions/Versioning/VersionAndroidManifest/test/android.tests.ts
+++ b/Extensions/Versioning/VersionAndroidManifest/test/android.tests.ts
@@ -24,19 +24,24 @@ describe ("Find files tests", () => {
 describe ("Version number split tests", () => {
 
     it ("should be able to get version name with . delimiters", () => {
-        var actual = getSplitVersionParts ("\d+.\d+.\d+.\d+", "{1}.{2}", "7.6.17334.5");
+        var actual = getSplitVersionParts (false, "\d+.\d+.\d+.\d+", "{1}.{2}", "7.6.17334.5");
         expect(actual).to.equal("7.6");
     });
 
     it ("should be able to get version code with . delimiters", () => {
-        var actual = getSplitVersionParts("\d+.\d+.\d+.\d+", "{3}{4}", "7.6.17334.5");
+        var actual = getSplitVersionParts(false, "\d+.\d+.\d+.\d+", "{3}{4}", "7.6.17334.5");
         expect(actual).to.equal("173345");
     });
 
     it ("should be able to get version name with complex delimiters", () => {
-        var actual = getSplitVersionParts ("\d+.\d+.\d+.\d+_\d+", "{1}-{2}-{3}-{4}-{5}", "2017.12.5.1_11760");
+        var actual = getSplitVersionParts (false, "\d+.\d+.\d+.\d+_\d+", "{1}-{2}-{3}-{4}-{5}", "2017.12.5.1_11760");
         expect(actual).to.equal("2017-12-5-1-11760");
      });
+
+     it ("should be able to inject a version", () => {
+      var actual = getSplitVersionParts (true, "\d+.\d+.\d+.\d+", "{1}.{2}.{3}", "7.6");
+      expect(actual).to.equal("7.6");
+  });
 
 });
 

--- a/Extensions/Versioning/VersionAngularFileTask/src/ApplyVersionToAngularFile.ts
+++ b/Extensions/Versioning/VersionAngularFileTask/src/ApplyVersionToAngularFile.ts
@@ -36,7 +36,7 @@ if (!fs.existsSync(path)) {
 const buildVersion = extractVersion(injectversion, versionRegex, versionNumber);
 console.log (`Extracted Build Version: ${buildVersion}`);
 
-const jsonVersion = getSplitVersionParts(versionRegex, versionForJSONFileFormat, buildVersion);
+const jsonVersion = getSplitVersionParts(injectversion, versionRegex, versionForJSONFileFormat, buildVersion);
 console.log (`Angular Version Name will be: ${jsonVersion}`);
 
 // Apply the version to the assembly property files

--- a/Extensions/Versioning/VersionAngularFileTask/src/AppyVersionToAngularFileFunctions.ts
+++ b/Extensions/Versioning/VersionAngularFileTask/src/AppyVersionToAngularFileFunctions.ts
@@ -2,11 +2,14 @@ import fs = require("fs");
 import path = require("path");
 import tl = require("vsts-task-lib/task");
 
-export function getSplitVersionParts (buildNumberFormat, outputFormat, version) {
-    const versionNumberSplitItems = version.split(extractDelimitersRegex(buildNumberFormat));
-    const versionNumberMatches = outputFormat.match(/\d/g);
-    const joinChar =  extractJoinChar(outputFormat);
-    const versionName = (versionNumberMatches.map((item) => versionNumberSplitItems[item - 1])).join(joinChar);
+export function getSplitVersionParts (injectversion, buildNumberFormat, outputFormat, version) {
+    var versionName = version;
+    if (injectversion === false) {
+        const versionNumberSplitItems = version.split(extractDelimitersRegex(buildNumberFormat));
+        const versionNumberMatches = outputFormat.match(/\d/g);
+        const joinChar =  extractJoinChar(outputFormat);
+        versionName = (versionNumberMatches.map((item) => versionNumberSplitItems[item - 1])).join(joinChar);
+    }
     return versionName;
 }
 

--- a/Extensions/Versioning/VersionAngularFileTask/test/FileProcessingTest.ts
+++ b/Extensions/Versioning/VersionAngularFileTask/test/FileProcessingTest.ts
@@ -15,14 +15,19 @@ const del = require("del");
 describe ("Version number split tests", () => {
 
   it ("should be able to get version name with . delimiters", () => {
-      var actual = getSplitVersionParts ("\d+.\d+.\d+.\d+", "{1}.{2}.{3}", "7.6.17334.5");
+      var actual = getSplitVersionParts (false, "\d+.\d+.\d+.\d+", "{1}.{2}.{3}", "7.6.17334.5");
       expect(actual).to.equal("7.6.17334");
   });
 
   it ("should be able to get version name with complex delimiters", () => {
-      var actual = getSplitVersionParts ("\d+.\d+.\d+.\d+_\d+", "{1}-{2}-{3}", "2017.12.5.1_11760");
+      var actual = getSplitVersionParts (false, "\d+.\d+.\d+.\d+_\d+", "{1}-{2}-{3}", "2017.12.5.1_11760");
       expect(actual).to.equal("2017-12-5");
    });
+
+   it ("should be able to injetc version and regex is ignored", () => {
+    var actual = getSplitVersionParts (true, "\d+.\d+.\d+.\d+", "{1}.{2}.{3}.{4}", "2.0.577-dev");
+    expect(actual).to.equal("2.0.577-dev");
+ });
 
 });
 


### PR DESCRIPTION
Fixes #1180

Removes the edge case where invalid output formats are passed and a version is directly injected