### PR TITLE
Added relatedWorkItems as additional parent data for pipeline artifacts

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
@@ -24,9 +24,10 @@ export class UnifiedArtifactDetails {
     build: Build;
     commits: Change[];
     workitems: WorkItem[];
+    relatedworkitems: WorkItem[];
     tests: TestCaseResult[];
     manualtests: EnrichedTestRun[];
-    constructor ( build: Build, commits: Change[], workitems: WorkItem[], tests: TestCaseResult[], manualtests: EnrichedTestRun[]) {
+    constructor ( build: Build, commits: Change[], workitems: WorkItem[], tests: TestCaseResult[], manualtests: EnrichedTestRun[], relatedworkitems: WorkItem[]) {
         this.build = build;
         if (commits) {
             this.commits = commits;
@@ -35,6 +36,11 @@ export class UnifiedArtifactDetails {
         }
         if (workitems) {
             this.workitems = workitems;
+        } else {
+            this.workitems = [];
+        }
+        if (relatedworkitems) {
+            this.relatedworkitems = relatedworkitems;
         } else {
             this.workitems = [];
         }
@@ -1345,7 +1351,7 @@ export async function generateReleaseNotes(
             try {
 
             if ((releaseId === undefined) || !releaseId) {
-
+                // A Classic Build or YAML Pipeline
                 // Overriding the active build id if applicable
                 if (overrideActiveBuildReleaseId) {
                     if (isNaN(parseInt(overrideActiveBuildReleaseId, 10))) {
@@ -1639,7 +1645,7 @@ export async function generateReleaseNotes(
                     globalManualTestConfigurations);
 
             } else {
-
+                // A Classic Release
                 // Overriding the active release id if applicable
                 if (overrideActiveBuildReleaseId) {
                     if (isNaN(parseInt(overrideActiveBuildReleaseId, 10))) {
@@ -1864,7 +1870,13 @@ export async function generateReleaseNotes(
                                         // we need to enrich the WI before we associate with the build
                                         let fullBuildWorkItems = await getFullWorkItemDetails(workItemTrackingApi, workitems);
 
-                                        globalBuilds.push(new UnifiedArtifactDetails(artifact, commits, fullBuildWorkItems, tests, manualtests));
+                                        var fullRelatedBuildItems = [];
+                                        if (getAllParents) {
+                                            agentApi.logInfo("Getting all parents of build WorkItems");
+                                            fullRelatedBuildItems = await getAllParentWorkitems(workItemTrackingApi, fullBuildWorkItems);
+                                        }
+
+                                        globalBuilds.push(new UnifiedArtifactDetails(artifact, commits, fullBuildWorkItems, tests, manualtests, fullRelatedBuildItems));
 
                                     }
                                 }

--- a/Extensions/XplatGenerateReleaseNotes/readme.md
+++ b/Extensions/XplatGenerateReleaseNotes/readme.md
@@ -171,7 +171,7 @@ The are a wide range of objects available to get data from within templates. Som
 |**tests** | the array of unique automated tests associated with any of the builds linked to the release or the release itself  |
 |**manualtests** | the array of manual Test Plan runs associated with any of the builds linked to the release |
 |**manualTestConfigurations** | the array of manual test configurations |
-| **relatedWorkItems** | the array of all work item associated with the release plus their direct parents or children and/or all parents depending on task parameters |
+| **relatedWorkItems** | the array of all work item associated with the release plus their direct parents or children (if `getParentsAndChildren` is set to `true`) and/or all parents depending on task parameters (if `getAllParents` is set to `true`) |  
 | **queryWorkItems** | the array of WI returned by by the WIQL, if a `wiqlWhereClause` is defined. Note that this array is completely independent of all other WI arrays.
 | **testedByWorkItems** | the array of all Test Case work items associated by a `Tested By` relation to a WI directly associated with the release |
 
@@ -181,7 +181,7 @@ The are a wide range of objects available to get data from within templates. Som
 | **releaseDetails** | the release details of the release that the task was triggered for.|
 | **compareReleaseDetails** | the the previous successful release that comparisons are being made against |
 | **releaseTests** | the list of test associated with the release e.g. integration tests |
-| **builds** | the array of the build artifacts that CS and WI are associated with. The associated WI, CS etc. in ths object are also will the main objects above, this is a filtered lits by build. Note that this is a object with multiple child properties. <br> - **build**  - the build details <br> -- **commits**  - the commits associated with this build <br> -- **workitems**  - the work items associated with the build<br> -- **tests**  - the work items associated with the build <br> -- **manualtests**  - the manual test runs associated with the build
+| **builds** | the array of the build artifacts that CS and WI are associated with. The associated WI, CS etc. in ths object are also will the main objects above, this is a filtered lits by build. Note that this is a object with multiple child properties. <br> - **build**  - the build details <br> -- **commits**  - the commits associated with this build <br> -- **workitems**  - the work items associated with the build<br> -- **tests**  - the work items associated with the build <br> -- **manualtests**  - the manual test runs associated with the build <br> -- **relatedWorkItems**  - the array direct parents or children (if `getParentsAndChildren` is set to `true`) and/or all parents (if `getAllParents` is set to `true`)
 
 ### Build objects (available for Classic UI based builds and any YAML based pipelines)
 | Object | Description |
@@ -189,7 +189,7 @@ The are a wide range of objects available to get data from within templates. Som
 | **buildDetails** | - if running in a build, the build details of the build that the task is running in. <br>- if running in a release it is the build that triggered the release.
 | **compareBuildDetails** | the previous successful build that comparisons are being made against, only available if `checkstage=true`
 | **currentStage** | if `checkstage=true` is enable this object is set to the details of the stage in the current build that is being used for the stage check
-| **consumedArtifacts** | the artifacts consumed by the pipeline, enriched with details of commits and workitems if available. If `checkStage=true` is set then this list should include all changes between the version of the artifact in the current and last successful run of the containing stage
+| **consumedArtifacts** | the artifacts consumed by the pipeline enriched with details where possible, the acutal objects depend on the artifact type <br> -- **artifactCategory** <br> -- **artifactType** <br> -- **properties** <br> -- **versionName** <br> -- **commits** - the commits associated with the artifact <br> -- **workitems** the workitems associated with the artifacts <br> -- **relatedworkitems** if  `getParentsAndChildren` is set to `true` and/or `getAllParents` is set to `true`. <br>If `checkStage=true` is set then this list should include all changes between the version of the artifact in the current and last successful run of the containing stage
 
 > **Note:** To dump all possible values via the template using the custom Handlebars extension `{{json propertyToDump}}` this runs a custom Handlebars extension to do the expansion. There are also options to dump these raw values to the build console log or to a file. (See below)
 


### PR DESCRIPTION
### What problem does this PR address?
GeneratereleaseNotes (XPlat version)
Added relatedWorkItems to pipeline artifacts if getAllParents is enabled. This is similar to the data available for the primary artifact.
  
### Is there a related Issue?
#1334 
  
### Have you...
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
