### PR TITLE
WIQL pull from workItemRelations for WorkItemLinks

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
@@ -1956,9 +1956,17 @@ export async function generateReleaseNotes(
                     undefined,
                     5000);
                     // need to get the result into the same format as used to enrich other WI arrays
-                    if (queryResponse && queryResponse.workItems) {
-                        var wiRefArray: ResourceRef[] = queryResponse.workItems.map(wi => ({id: wi.id.toString(), url: undefined})) as ResourceRef[];
-                        // enrich the items
+                    if (queryResponse){
+                        var wiRefArray: ResourceRef[];
+                        if(wiqlFromTarget === "WorkItems" && queryResponse.workItems) {
+                            wiRefArray = queryResponse.workItems.map(wi => ({id: wi.id.toString(), url: undefined})) as ResourceRef[];
+                        }
+                        else if(wiqlFromTarget === "WorkItemLinks" && queryResponse.workItemRelations)
+                        {
+                             wiRefArray = queryResponse.workItemRelations.map(wi => ({id: wi.target?.id.toString(), url: undefined})) as ResourceRef[];
+                             removeDuplicates(wiRefArray);
+                        }
+                         // enrich the items
                         queryWorkItems = await getFullWorkItemDetails(workItemTrackingApi, wiRefArray);
                         agentApi.logInfo(`Found ${queryWorkItems.length} WI using WIQL`);
                     } else {

--- a/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/V3/ReleaseNotesFunctions.ts
@@ -1956,13 +1956,12 @@ export async function generateReleaseNotes(
                     undefined,
                     5000);
                     // need to get the result into the same format as used to enrich other WI arrays
-                    if (queryResponse){
+                    if (queryResponse) {
                         var wiRefArray: ResourceRef[];
-                        if(wiqlFromTarget === "WorkItems" && queryResponse.workItems) {
+                        if (wiqlFromTarget === "WorkItems" && queryResponse.workItems) {
                             wiRefArray = queryResponse.workItems.map(wi => ({id: wi.id.toString(), url: undefined})) as ResourceRef[];
                         }
-                        else if(wiqlFromTarget === "WorkItemLinks" && queryResponse.workItemRelations)
-                        {
+                        else if (wiqlFromTarget === "WorkItemLinks" && queryResponse.workItemRelations) {
                              wiRefArray = queryResponse.workItemRelations.map(wi => ({id: wi.target?.id.toString(), url: undefined})) as ResourceRef[];
                              removeDuplicates(wiRefArray);
                         }


### PR DESCRIPTION
The WIQL flow was not handling the alternate return object for when the wiqlFromTarget was set to WorkItemLinks resulting in no errors but no results ever processed even when the query had results. Since various linkage types are returned I decided to just pull all and dedupe them.

Not positive if target?.id is the correct source for all flows though.

### What problem does this PR address?
--[XplatGenerateReleaseNotes](https://github.com/rfennell/AzurePipelines/tree/main/Extensions/XplatGenerateReleaseNotes)--
--WIQL pull from workItemRelations for WorkItemLinks--
  
### Is there a related Issue?
-- Fixes #1346 --
  
### Have you...
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md

Yes I am, I am not sure what exactly to update in your readme