### PR TITLE
Update social media push

### DIFF
--- a/Extensions/ArtifactDescription/azure-pipelines.yml
+++ b/Extensions/ArtifactDescription/azure-pipelines.yml
@@ -167,15 +167,12 @@ stages:
     - job: Post_Publish
       dependsOn: Public_Deployment
       variables:
-      - group: mastodon
-      - group: twitter
+      - group: socialMedia
       pool:
         vmImage: '$(vmImage)'
       steps:
         - template: ..\..\YAMLTemplates\post-publish.yml
           parameters:
-              buildNumber: $(Build.BuildNumber)
-              extensionName: $(Build.DefinitionName)
-              mastodonUrl: $(mastodonurl)
-              mastodonKey: $(mastodonkey)
-              twitterUrl: $(twitterurl)
+            buildNumber: $(Build.BuildNumber)
+            extensionName: $(Build.DefinitionName)
+            socialmediaLogicAppURL: $(socialmediaLogicAppURL)

--- a/Extensions/BuildUpdating/azure-pipelines.yml
+++ b/Extensions/BuildUpdating/azure-pipelines.yml
@@ -226,15 +226,12 @@ stages:
     - job: Post_Publish
       dependsOn: Public_Deployment
       variables:
-      - group: mastodon
-      - group: twitter
+      - group: socialMedia
       pool:
         vmImage: '$(vmImage)'
       steps:
         - template: ..\..\YAMLTemplates\post-publish.yml
           parameters:
-              buildNumber: $(Build.BuildNumber)
-              extensionName: $(Build.DefinitionName)
-              mastodonUrl: $(mastodonurl)
-              mastodonKey: $(mastodonkey)
-              twitterUrl: $(twitterurl)
+            buildNumber: $(Build.BuildNumber)
+            extensionName: $(Build.DefinitionName)
+            socialmediaLogicAppURL: $(socialmediaLogicAppURL)

--- a/Extensions/DevTestLab/azure-pipelines-build.yml
+++ b/Extensions/DevTestLab/azure-pipelines-build.yml
@@ -164,15 +164,12 @@ stages:
     - job: Post_Publish
       dependsOn: Public_Deployment
       variables:
-      - group: mastodon
-      - group: twitter
+      - group: socialMedia
       pool:
         vmImage: '$(vmImage)'
       steps:
         - template: ..\..\YAMLTemplates\post-publish.yml
           parameters:
-              buildNumber: $(Build.BuildNumber)
-              extensionName: $(Build.DefinitionName)
-              mastodonUrl: $(mastodonurl)
-              mastodonKey: $(mastodonkey)
-              twitterUrl: $(twitterurl)
+            buildNumber: $(Build.BuildNumber)
+            extensionName: $(Build.DefinitionName)
+            socialmediaLogicAppURL: $(socialmediaLogicAppURL)

--- a/Extensions/FileUtilities/azure-pipelines-build.yml
+++ b/Extensions/FileUtilities/azure-pipelines-build.yml
@@ -337,15 +337,12 @@ stages:
     - job: Post_Publish
       dependsOn: Public_Deployment
       variables:
-      - group: mastodon
-      - group: twitter
+      - group: socialMedia
       pool:
         vmImage: '$(vmImage)'
       steps:
         - template: ..\..\YAMLTemplates\post-publish.yml
           parameters:
-              buildNumber: $(Build.BuildNumber)
-              extensionName: $(Build.DefinitionName)
-              mastodonUrl: $(mastodonurl)
-              mastodonKey: $(mastodonkey)
-              twitterUrl: $(twitterurl)
+            buildNumber: $(Build.BuildNumber)
+            extensionName: $(Build.DefinitionName)
+            socialmediaLogicAppURL: $(socialmediaLogicAppURL)

--- a/Extensions/Versioning/azure-pipelines-build.yml
+++ b/Extensions/Versioning/azure-pipelines-build.yml
@@ -305,15 +305,12 @@ stages:
     - job: Post_Publish
       dependsOn: Public_Deployment
       variables:
-      - group: mastodon
-      - group: twitter
+      - group: socialMedia
       pool:
         vmImage: '$(vmImage)'
       steps:
         - template: ..\..\YAMLTemplates\post-publish.yml
           parameters:
-              buildNumber: $(Build.BuildNumber)
-              extensionName: $(Build.DefinitionName)
-              mastodonUrl: $(mastodonurl)
-              mastodonKey: $(mastodonkey)
-              twitterUrl: $(twitterurl)
+            buildNumber: $(Build.BuildNumber)
+            extensionName: $(Build.DefinitionName)
+            socialmediaLogicAppURL: $(socialmediaLogicAppURL)

--- a/Extensions/WikiPDFExport/azure-pipelines-build.yml
+++ b/Extensions/WikiPDFExport/azure-pipelines-build.yml
@@ -197,15 +197,12 @@ stages:
     - job: Post_Publish
       dependsOn: Public_Deployment
       variables:
-      - group: mastodon
-      - group: twitter
+      - group: socialMedia
       pool:
         vmImage: '$(vmImage)'
       steps:
         - template: ..\..\YAMLTemplates\post-publish.yml
           parameters:
-              buildNumber: $(Build.BuildNumber)
-              extensionName: $(Build.DefinitionName)
-              mastodonUrl: $(mastodonurl)
-              mastodonKey: $(mastodonkey)
-              twitterUrl: $(twitterurl)
+            buildNumber: $(Build.BuildNumber)
+            extensionName: $(Build.DefinitionName)
+            socialmediaLogicAppURL: $(socialmediaLogicAppURL)

--- a/Extensions/WikiUpdater/azure-pipelines-build.yml
+++ b/Extensions/WikiUpdater/azure-pipelines-build.yml
@@ -441,15 +441,12 @@ stages:
     - job: Post_Publish
       dependsOn: Public_Deployment
       variables:
-      - group: mastodon
-      - group: twitter
+      - group: socialMedia
       pool:
         vmImage: '$(vmImage)'
       steps:
         - template: ..\..\YAMLTemplates\post-publish.yml
           parameters:
-              buildNumber: $(Build.BuildNumber)
-              extensionName: $(Build.DefinitionName)
-              mastodonUrl: $(mastodonurl)
-              mastodonKey: $(mastodonkey)
-              twitterUrl: $(twitterurl)
+            buildNumber: $(Build.BuildNumber)
+            extensionName: $(Build.DefinitionName)
+            socialmediaLogicAppURL: $(socialmediaLogicAppURL)

--- a/Extensions/XplatGenerateReleaseNotes/azure-pipelines-build.yml
+++ b/Extensions/XplatGenerateReleaseNotes/azure-pipelines-build.yml
@@ -215,16 +215,13 @@ stages:
     - job: Post_Publish
       dependsOn: Public_Deployment
       variables:
-      - group: mastodon
-      - group: twitter
+      - group: socialMedia
       pool:
         vmImage: '$(vmImage)'
       steps:
         - template: ..\..\YAMLTemplates\post-publish.yml
           parameters:
-              buildNumber: $(Build.BuildNumber)
-              extensionName: $(Build.DefinitionName)
-              mastodonUrl: $(mastodonurl)
-              mastodonKey: $(mastodonkey)
-              twitterUrl: $(twitterurl)
+            buildNumber: $(Build.BuildNumber)
+            extensionName: $(Build.DefinitionName)
+            socialmediaLogicAppURL: $(socialmediaLogicAppURL)
 

--- a/Extensions/YamlGenerator/azure-pipelines-build.yml
+++ b/Extensions/YamlGenerator/azure-pipelines-build.yml
@@ -153,15 +153,12 @@ stages:
     - job: Post_Publish
       dependsOn: Public_Deployment
       variables:
-      - group: mastodon
-      - group: twitter
+      - group: socialMedia
       pool:
         vmImage: '$(vmImage)'
       steps:
         - template: ..\..\YAMLTemplates\post-publish.yml
           parameters:
-              buildNumber: $(Build.BuildNumber)
-              extensionName: $(Build.DefinitionName)
-              mastodonUrl: $(mastodonurl)
-              mastodonKey: $(mastodonkey)
-              twitterUrl: $(twitterurl)
+            buildNumber: $(Build.BuildNumber)
+            extensionName: $(Build.DefinitionName)
+            socialmediaLogicAppURL: $(socialmediaLogicAppURL)

--- a/YAMLTemplates/post-publish-tester.yml
+++ b/YAMLTemplates/post-publish-tester.yml
@@ -1,0 +1,17 @@
+name: $(Major).$(Minor).$(rev:r)  # build numbering format
+
+trigger: none
+stages:
+  - stage: Public
+    jobs:
+    - job: Post_Publish
+      variables:
+      - group: socialMedia
+      pool:
+        vmImage: window-latest
+      steps:
+        - template: .\post-publish.yml
+          parameters:
+              buildNumber: $(Build.BuildNumber)
+              extensionName: TesterName
+              socialmediaLogicAppURL: $(socialmediaLogicAppURL)

--- a/YAMLTemplates/post-publish-tester.yml
+++ b/YAMLTemplates/post-publish-tester.yml
@@ -3,8 +3,9 @@ name: $(Major).$(Minor).$(rev:r)  # build numbering format
 trigger: none
 
 variables:
-  major : 1
-  minor : 0
+  # declared in the pipeline UI
+  #  major
+  #  minor
 stages:
   - stage: Public
     jobs:
@@ -17,5 +18,5 @@ stages:
         - template: .\post-publish.yml
           parameters:
               buildNumber: $(Build.BuildNumber)
-              extensionName: TesterName
+              extensionName: $(Build.DefinitionName)
               socialmediaLogicAppURL: $(socialmediaLogicAppURL)

--- a/YAMLTemplates/post-publish-tester.yml
+++ b/YAMLTemplates/post-publish-tester.yml
@@ -2,7 +2,7 @@ name: $(Major).$(Minor).$(rev:r)  # build numbering format
 
 trigger: none
 
-variables:
+#variables:
   # declared in the pipeline UI
   #  major
   #  minor

--- a/YAMLTemplates/post-publish-tester.yml
+++ b/YAMLTemplates/post-publish-tester.yml
@@ -1,6 +1,10 @@
 name: $(Major).$(Minor).$(rev:r)  # build numbering format
 
 trigger: none
+
+variables:
+  major : 1
+  minor : 0
 stages:
   - stage: Public
     jobs:
@@ -8,7 +12,7 @@ stages:
       variables:
       - group: socialMedia
       pool:
-        vmImage: window-latest
+        vmImage: windows-latest
       steps:
         - template: .\post-publish.yml
           parameters:

--- a/YAMLTemplates/post-publish.yml
+++ b/YAMLTemplates/post-publish.yml
@@ -24,7 +24,7 @@ steps:
 
    write-host "$msg"
    $uri = "${{parameters.socialmediaLogicAppURL}}" 
-   $body = '{ "Message": $msg}'
+   $body = '{ "Message": "$msg"}'
    
    Invoke-WebRequest -Uri $uri -Method POST -Body $body -Headers $headers -ContentType "application/json"
   displayName: 'Create social media posts about new release'

--- a/YAMLTemplates/post-publish.yml
+++ b/YAMLTemplates/post-publish.yml
@@ -22,7 +22,7 @@ steps:
 - pwsh: |
    $msg = "I have just released Version ${{parameters.buildNumber}} of my Azure DevOps Pipeline ${{parameters.extensionName}} http://bit.ly/VSTS-RF $(OutputedText) "
 
-   write-host "$msg"
+   write-host "Posting message: $msg"
    $uri = "${{parameters.socialmediaLogicAppURL}}" 
    $body = '{ "Message": "$msg"}'
    

--- a/YAMLTemplates/post-publish.yml
+++ b/YAMLTemplates/post-publish.yml
@@ -3,11 +3,7 @@ parameters:
   type: string
 - name: extensionName
   type: string
-- name: mastodonUrl
-  type: string
-- name: mastodonKey
-  type: string
-- name: twitterUrl
+- name: socialmediaLogicAppURL
   type: string 
 
 steps:  
@@ -24,15 +20,12 @@ steps:
     OutputText: 'OutputedText'
 
 - pwsh: |
-   # Write your PowerShell commands here.
-   
-   $uri = "${{parameters.twitterUrl}}" 
-   $body = '{ "Tweet": "I have just released Version ${{parameters.buildNumber}} of my Azure DevOps Pipeline ${{parameters.extensionName}} http://bit.ly/VSTS-RF $(OutputedText) "}'
+   $msg = "I have just released Version ${{parameters.buildNumber}} of my Azure DevOps Pipeline ${{parameters.extensionName}} http://bit.ly/VSTS-RF $(OutputedText) "
+
+   write-host "$msg"
+   $uri = "${{parameters.socialmediaLogicAppURL}}" 
+   $body = '{ "Message": $msg}'
    
    Invoke-WebRequest -Uri $uri -Method POST -Body $body -Headers $headers -ContentType "application/json"
-  displayName: 'Send Tweet about new release'
+  displayName: 'Create social media posts about new release'
 
-- powershell: |
-    Write-Host "Posting to Mastodon"
-    Invoke-WebRequest -Uri ${{parameters.mastodonUrl}}/api/v1/statuses -Method POST -Headers @{Authorization='Bearer ${{parameters.mastodonKey}}'}  -Body @{status='I have just released Version ${{parameters.buildNumber}} of my Azure DevOps Pipeline ${{parameters.extensionName}} http://bit.ly/VSTS-RF $(OutputedText)'}
-  displayName: 'Posting to Mastodon about new release'

--- a/YAMLTemplates/post-publish.yml
+++ b/YAMLTemplates/post-publish.yml
@@ -24,7 +24,7 @@ steps:
 
    write-host "Posting message: $msg"
    $uri = "${{parameters.socialmediaLogicAppURL}}" 
-   $body = '{ "Message": "$msg"}'
+   $body = "{ `"Message`": `"$msg`"}"
    
    Invoke-WebRequest -Uri $uri -Method POST -Body $body -Headers $headers -ContentType "application/json"
   displayName: 'Create social media posts about new release'


### PR DESCRIPTION
In the past I used various tasks to do social media pushes when I released a new extension. I recently moved the twitter post (due to Twitter API changes) to a Logic App. After a bit more thought it seemed a good idea to move all social posts to this platform, so it matches the way I do post for blog post entries