### PR TITLE
Fix the filter to find the task manifest

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/azure-pipelines-build.yml
+++ b/Extensions/XplatGenerateReleaseNotes/azure-pipelines-build.yml
@@ -70,7 +70,7 @@ stages:
           Contents: |
             readme.md
             vss-extension.json
-            V?\task.json
+            **\task\task.json
           TargetFolder: '$(Build.ArtifactStagingDirectory)\\$(artifactLocationName)'
 
       - task: PublishPipelineArtifact@0


### PR DESCRIPTION
This is required to make sure the YAML based documentation is correctly created. This occurred because of the refactoring of the folder structure

