### PR TITLE
XPlatGenerateReleaseNotesTask: Fix log message about deployments found

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/src/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/src/ReleaseNotesFunctions.ts
@@ -299,7 +299,7 @@ export async function getMostRecentSuccessfulDeployment(
             if (successfulDeployments && successfulDeployments.length > 0) {
                 agentApi.logInfo (`Found ${successfulDeployments.length} releases to consider`);
                 successfulDeployments.forEach(deployment => {
-                    agentApi.logDebug (`Found DeploymentId ${deployment.id} with ReleaseID ${deployment.release.id} with the Status ${deployment.deploymentStatus}`);
+                    agentApi.logDebug (`Found DeploymentId ${deployment.id} with ReleaseID ${deployment.release.id} with the Deployment Status ${deployment.deploymentStatus}`);
                 });
 
                 if (overrideBuildReleaseId && !isNaN(parseInt(overrideBuildReleaseId))) {

--- a/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/src/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/src/ReleaseNotesFunctions.ts
@@ -299,7 +299,7 @@ export async function getMostRecentSuccessfulDeployment(
             if (successfulDeployments && successfulDeployments.length > 0) {
                 agentApi.logInfo (`Found ${successfulDeployments.length} releases to consider`);
                 successfulDeployments.forEach(deployment => {
-                    agentApi.logDebug (`Found ReleaseID ${deployment.id} with the Status ${deployment.deploymentStatus}`);
+                    agentApi.logDebug (`Found DeploymentId ${deployment.id} with ReleaseID ${deployment.release.id} with the Status ${deployment.deploymentStatus}`);
                 });
 
                 if (overrideBuildReleaseId && !isNaN(parseInt(overrideBuildReleaseId))) {


### PR DESCRIPTION
### What problem does this PR address?
Task: **XPlatGenerateReleaseNotesTask**

The current log message pretends to log the **Release Id & Status** but its actually logging the **Deployment's Id & Status** which is different, It causes confusion when debugging the logs,  In this PR I've fixed the message


