### PR TITLE
fix: reenable vscode debug stepping

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.2.0",
+    "version": "0.3.0",
     "configurations":
     [
         {
             "name": "Generate Release Notes Console Tester",
-            "program": "${workspaceFolder}/Extensions/XplatGenerateReleaseNotes/v3/testconsole/GenerateReleaseNotesConsoleTester.js",
+            "program": "${workspaceFolder}/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/testconsole/GenerateReleaseNotesConsoleTester.js",
             "request": "launch",
-            "cwd": "${workspaceRoot}/Extensions/XplatGenerateReleaseNotes/v3/testconsole",
+            "cwd": "${workspaceFolder}/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/testconsole",
             "type": "node",
             "args": [ 
                 "--filename", "build-settings.json", 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,9 @@
                 "--pat", "<pat>",
                 "--githubpat", "<pat>",
                 "--bitbucketuser", "<user>",
-                "--bitbucketsecret", "<secret>"]
+                "--bitbucketsecret", "<secret>",
+                "--payloadFile", "<file>"
+            ]
         },
     
         {

--- a/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/testconsole/readme.md
+++ b/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/testconsole/readme.md
@@ -107,7 +107,9 @@ You can debug the task using Visual Studio Code. To do this have a `launch.json`
                 "--pat", "<pat>",
                 "--githubpat", "<pat>",
                 "--bitbucketuser", "<user>",
-                "--bitbucketsecret", "<secret>"]
+                "--bitbucketsecret", "<secret>",
+                "--payloadFile", "<file>"
+            ]
         },
     
         {

--- a/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/testconsole/readme.md
+++ b/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/testconsole/readme.md
@@ -91,24 +91,30 @@ To dump this JSON data, set the following values in the configuration file
 ### Visual Studio Code
 You can debug the task using Visual Studio Code. To do this have a `launch.json` file with the following configuration
 
-```
+```json
 {
-    "version": "0.2.0",
+    "version": "0.3.0",
     "configurations":
     [
         {
             "name": "Generate Release Notes Console Tester",
-            "program": "${workspaceFolder}/Extensions/XplatGenerateReleaseNotes/v3/testconsole/GenerateReleaseNotesConsoleTester.js",
+            "program": "${workspaceFolder}/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/testconsole/GenerateReleaseNotesConsoleTester.js",
             "request": "launch",
-            "cwd": "${workspaceRoot}/Extensions/XplatGenerateReleaseNotes/v3/testconsole",
+            "cwd": "${workspaceFolder}/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/testconsole",
             "type": "node",
-            "args": [
-                "--filename", "build-settings.json",
+            "args": [ 
+                "--filename", "build-settings.json", 
                 "--pat", "<pat>",
                 "--githubpat", "<pat>",
                 "--bitbucketuser", "<user>",
-                "--bitbucketsecret", "<secret>",
-                "--payloadFile", "<file>"]
+                "--bitbucketsecret", "<secret>"]
+        },
+    
+        {
+            "name": "PowerShell - current file",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "${file}"
         }
     ]
 }

--- a/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/tsconfig.json
+++ b/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/tsconfig.json
@@ -10,7 +10,8 @@
           "src/",
           "test/",
           "testconsole/"
-        ]
+        ],
+        "sourceRoot": "../"
     },
     "exclude": [
         "node_modules"


### PR DESCRIPTION
### What problem does this PR address?
XplatGenerateReleaseNotes/testconsole

The files are moved as part of `npm run build` so
the sources in the .js.maps needs to be set accordingly, which
is what the sourceRoot property does here.
  
### Is there a related Issue?
N/A
  
### Have you...
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
