### PR TITLE
fix: replicate important env var for debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
             "request": "launch",
             "cwd": "${workspaceFolder}/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/testconsole",
             "type": "node",
+            "env": { "System_StageName": "__default" },
             "args": [ 
                 "--filename", "build-settings.json", 
                 "--pat", "<pat>",


### PR DESCRIPTION
This env var is set for the Task in Azure and
affects the data retrieved so it should also
be set when using the test console

### What problem does this PR address?
XplatGenerateReleaseNotes test console

  
### Is there a related Issue?
--add Issue number--
#1563 
Does not fully resolve the issue (running the test console without debugging does not get the env var set) but is a step in that direction
  
### Have you...
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
