### PR TITLE
Remove V2 Agent (Node10 execution engine) support for the WIKI related tasks

### DIFF
--- a/Extensions/WikiPDFExport/WikiPDFExportTask/task/task.json
+++ b/Extensions/WikiPDFExport/WikiPDFExportTask/task/task.json
@@ -162,10 +162,6 @@
   ],
   "instanceNameFormat": "WIKI PDF Exporter",
   "execution": {
-    "Node10": {
-      "target": "WikiPDFExportTask.js",
-      "argumentFormat": ""
-    },
     "Node16": {
       "target": "WikiPDFExportTask.js",
       "argumentFormat": ""

--- a/Extensions/WikiPDFExport/test-stage.yml
+++ b/Extensions/WikiPDFExport/test-stage.yml
@@ -40,7 +40,7 @@ steps:
         -  **Message:** {{this.message}}
         -  **Commited by:** {{this.author.displayName}}
       {{/forEach}}
-- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@4
+- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@3
   displayName: 'Export Single File'
   inputs:
     cloneRepo: false
@@ -49,7 +49,7 @@ steps:
     singleFile: 'inline.md'
     outputFile: '$(Build.ArtifactStagingDirectory)/PDF/$(Agent.OS)-singleFile.pdf'
     downloadPath: '${{parameters.localpath}}'
-- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@4
+- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@3
   displayName: 'Export Single File'
   inputs:
     cloneRepo: false
@@ -58,7 +58,7 @@ steps:
     singleFile: 'inline.md'
     outputFile: '$(Build.ArtifactStagingDirectory)/PDF/$(Agent.OS)-singleFile.pdf'
     downloadPath: '${{parameters.localpath}}'
-- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@4
+- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@3
   displayName: 'Export Public GitHub WIKI'
   condition: succeededOrFailed()
   inputs:
@@ -68,7 +68,7 @@ steps:
     localpath: '$(System.DefaultWorkingDirectory)/GitHubRepo'
     outputFile: '$(Build.ArtifactStagingDirectory)/PDF/$(Agent.OS)-publicGitHub.pdf'
     downloadPath: '${{parameters.localpath}}'
-- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@4
+- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@3
   displayName: 'Export Azure DevOps WIKI'
   condition: succeededOrFailed()
   inputs:
@@ -77,7 +77,7 @@ steps:
     useAgentToken: true
     outputFile: '$(Build.ArtifactStagingDirectory)/PDF/$(Agent.OS)-Azrepo.pdf'
     downloadPath: '${{parameters.localpath}}'
-- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@4
+- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@3
   displayName: 'Export part of the Azure DevOps WIKI'
   condition: succeededOrFailed()
   inputs:
@@ -88,7 +88,7 @@ steps:
     localpath: '$(System.DefaultWorkingDirectory)/repopartial'
     rootExportPath: '$(System.DefaultWorkingDirectory)/repopartial/folder'
     downloadPath: '${{parameters.localpath}}'
-- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@4
+- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@3
   displayName: 'Export single part of the Azure DevOps WIKI'
   condition: succeededOrFailed()
   inputs:
@@ -100,7 +100,7 @@ steps:
     rootExportPath: '$(System.DefaultWorkingDirectory)/repopartial1/folder'
     downloadPath: '${{parameters.localpath}}'
     singlefile: 'test1.md'
-- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@4
+- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@3
   displayName: 'Export Azure DevOps WIKI without downloading tool'
   condition: and(succeededOrFailed(), eq(variables['AGENT.OS'], 'Windows_NT'))
   inputs:

--- a/Extensions/WikiPDFExport/test-stage.yml
+++ b/Extensions/WikiPDFExport/test-stage.yml
@@ -40,7 +40,7 @@ steps:
         -  **Message:** {{this.message}}
         -  **Commited by:** {{this.author.displayName}}
       {{/forEach}}
-- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@3
+- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@4
   displayName: 'Export Single File'
   inputs:
     cloneRepo: false
@@ -49,7 +49,7 @@ steps:
     singleFile: 'inline.md'
     outputFile: '$(Build.ArtifactStagingDirectory)/PDF/$(Agent.OS)-singleFile.pdf'
     downloadPath: '${{parameters.localpath}}'
-- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@3
+- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@4
   displayName: 'Export Single File'
   inputs:
     cloneRepo: false
@@ -58,7 +58,7 @@ steps:
     singleFile: 'inline.md'
     outputFile: '$(Build.ArtifactStagingDirectory)/PDF/$(Agent.OS)-singleFile.pdf'
     downloadPath: '${{parameters.localpath}}'
-- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@3
+- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@4
   displayName: 'Export Public GitHub WIKI'
   condition: succeededOrFailed()
   inputs:
@@ -68,7 +68,7 @@ steps:
     localpath: '$(System.DefaultWorkingDirectory)/GitHubRepo'
     outputFile: '$(Build.ArtifactStagingDirectory)/PDF/$(Agent.OS)-publicGitHub.pdf'
     downloadPath: '${{parameters.localpath}}'
-- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@3
+- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@4
   displayName: 'Export Azure DevOps WIKI'
   condition: succeededOrFailed()
   inputs:
@@ -77,7 +77,7 @@ steps:
     useAgentToken: true
     outputFile: '$(Build.ArtifactStagingDirectory)/PDF/$(Agent.OS)-Azrepo.pdf'
     downloadPath: '${{parameters.localpath}}'
-- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@3
+- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@4
   displayName: 'Export part of the Azure DevOps WIKI'
   condition: succeededOrFailed()
   inputs:
@@ -88,7 +88,7 @@ steps:
     localpath: '$(System.DefaultWorkingDirectory)/repopartial'
     rootExportPath: '$(System.DefaultWorkingDirectory)/repopartial/folder'
     downloadPath: '${{parameters.localpath}}'
-- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@3
+- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@4
   displayName: 'Export single part of the Azure DevOps WIKI'
   condition: succeededOrFailed()
   inputs:
@@ -100,7 +100,7 @@ steps:
     rootExportPath: '$(System.DefaultWorkingDirectory)/repopartial1/folder'
     downloadPath: '${{parameters.localpath}}'
     singlefile: 'test1.md'
-- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@3
+- task: richardfennellBM.BM-VSTS-WikiPDFExport-Tasks-DEV.WikiPDFExportTask.WikiPdfExportTask@4
   displayName: 'Export Azure DevOps WIKI without downloading tool'
   condition: and(succeededOrFailed(), eq(variables['AGENT.OS'], 'Windows_NT'))
   inputs:

--- a/Extensions/WikiUpdater/WikiFolderUpdaterTask/task/task.json
+++ b/Extensions/WikiUpdater/WikiFolderUpdaterTask/task/task.json
@@ -209,10 +209,6 @@
   ],
   "instanceNameFormat": "Git based WIKI Folder Updater",
   "execution": {
-    "Node10": {
-      "target": "GitWikiTask.js",
-      "argumentFormat": ""
-    },
     "Node16": {
       "target": "GitWikiTask.js",
       "argumentFormat": ""

--- a/Extensions/WikiUpdater/WikiUpdaterTask/task/task.json
+++ b/Extensions/WikiUpdater/WikiUpdaterTask/task/task.json
@@ -299,11 +299,7 @@
   ],
   "instanceNameFormat": "Git based WIKI File Updater",
   "execution": {
-    "Node10": {
-      "target": "GitWikiTask.js",
-      "argumentFormat": ""
-    },
-    "Node16": {
+      "Node16": {
       "target": "GitWikiTask.js",
       "argumentFormat": ""
     }

--- a/Extensions/WikiUpdater/multi-file-test-steps.yml
+++ b/Extensions/WikiUpdater/multi-file-test-steps.yml
@@ -7,7 +7,7 @@ steps:
     fetchDepth: 0
     lfs: false
 
-  - task: WikiFolderUpdaterTask@2
+  - task: WikiFolderUpdaterTask@3
     inputs:
       repo: 'dev.azure.com/richardfennell/GitHub/_git/GitHub.wiki'
       targetFolder: '${{parameters.platform}}-folder'
@@ -20,7 +20,7 @@ steps:
       useAgentToken: true
       localpath: '$(System.DefaultWorkingDirectory)\azurerepoasagentfolder'
 
-  - task: WikiFolderUpdaterTask@2
+  - task: WikiFolderUpdaterTask@3
     inputs:
       repo: 'https://richardfennell@dev.azure.com/richardfennell/GitHub/_git/GitHub.wiki'
       targetFolder: '${{parameters.platform}}-folder'

--- a/Extensions/WikiUpdater/multi-file-test-steps.yml
+++ b/Extensions/WikiUpdater/multi-file-test-steps.yml
@@ -7,7 +7,7 @@ steps:
     fetchDepth: 0
     lfs: false
 
-  - task: WikiFolderUpdaterTask@3
+  - task: WikiFolderUpdaterTask@2
     inputs:
       repo: 'dev.azure.com/richardfennell/GitHub/_git/GitHub.wiki'
       targetFolder: '${{parameters.platform}}-folder'
@@ -20,7 +20,7 @@ steps:
       useAgentToken: true
       localpath: '$(System.DefaultWorkingDirectory)\azurerepoasagentfolder'
 
-  - task: WikiFolderUpdaterTask@3
+  - task: WikiFolderUpdaterTask@2
     inputs:
       repo: 'https://richardfennell@dev.azure.com/richardfennell/GitHub/_git/GitHub.wiki'
       targetFolder: '${{parameters.platform}}-folder'

--- a/Extensions/WikiUpdater/single-file-test-steps.yml
+++ b/Extensions/WikiUpdater/single-file-test-steps.yml
@@ -27,7 +27,7 @@ steps:
             -  **Message:** {{this.message}}
             -  **Commited by:** {{this.author.displayName}}
           {{/forEach}}
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
     displayName: 'Git based WIKI Updater - GitHub'
     inputs:
       repo: github.com/rfennell/demorepo.wiki
@@ -46,7 +46,7 @@ steps:
       user: rfennell
       password: '$(githubPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\githubrepo'
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
     displayName: 'Git based WIKI Updater - GitHub append'
     inputs:
       repo: github.com/rfennell/demorepo.wiki
@@ -64,7 +64,7 @@ steps:
       user: rfennell
       password: '$(githubPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\githubrepo'
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
     displayName: 'Git based WIKI Updater - GitHub prepend '
     inputs:
       repo: github.com/rfennell/demorepo.wiki
@@ -84,7 +84,7 @@ steps:
       user: rfennell
       password: '$(githubPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\githubrepo'
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
     displayName: 'Git based WIKI Updater - GitHub folder'
     inputs:
       repo: github.com/rfennell/demorepo.wiki
@@ -104,7 +104,7 @@ steps:
       user: rfennell
       password: '$(githubPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\githubrepo'
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
     displayName: 'Git based WIKI Updater - GitHub folder with spaces'
     inputs:
       repo: github.com/rfennell/demorepo.wiki
@@ -125,7 +125,7 @@ steps:
       password: '$(githubPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\githubrepo'
       fixSpaces: true
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
     displayName: 'Git based WIKI Updater - Azure DevOps with Creds update .order file'
     inputs:
       repo: 'dev.azure.com/richardfennell/Git%20project/_git/Git-project.wiki'
@@ -143,7 +143,7 @@ steps:
       password: '$(AzureDevOpsPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\azurerepowithcreds'
       updateOrderFile: true
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
     displayName: 'Git based WIKI Updater - Azure DevOps with Creds update TestFolder/.order file'
     inputs:
       repo: 'dev.azure.com/richardfennell/Git%20project/_git/Git-project.wiki'
@@ -165,7 +165,7 @@ steps:
       appendToFile: false
       injecttoc: true
       orderFilePath: "TestFolder"
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
     displayName: 'Git based WIKI Updater - Azure DevOps in branch'
     inputs:
       repo: 'dev.azure.com/richardfennell/Git%20project/_git/WikiRepo'
@@ -183,7 +183,7 @@ steps:
       password: '$(AzureDevOpsPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\azurerepowithcreds'
       branch: b1
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
     displayName: 'Git based WIKI Updater - Azure DevOps into Folder'
     inputs:
       repo: 'dev.azure.com/richardfennell/Git%20project/_git/Git-project.wiki'
@@ -200,7 +200,7 @@ steps:
       user: richardfennell
       password: '$(AzureDevOpsPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\azurerepowithcreds'
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
     displayName: 'Git based WIKI Updater - Azure DevOps as Agent'
     inputs:
       repo: 'dev.azure.com/richardfennell/GitHub/_git/GitHub.wiki'
@@ -216,7 +216,7 @@ steps:
       gitemail: 'build@demo'
       useAgentToken: true
       localpath: '$(System.DefaultWorkingDirectory)\azurerepoasagent'
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
     displayName: 'Git based WIKI Updater - Azure DevOps as Agent with full url'
     inputs:
       repo: 'https://richardfennell@dev.azure.com/richardfennell/GitHub/_git/GitHub.wiki'

--- a/Extensions/WikiUpdater/single-file-test-steps.yml
+++ b/Extensions/WikiUpdater/single-file-test-steps.yml
@@ -27,7 +27,7 @@ steps:
             -  **Message:** {{this.message}}
             -  **Commited by:** {{this.author.displayName}}
           {{/forEach}}
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
     displayName: 'Git based WIKI Updater - GitHub'
     inputs:
       repo: github.com/rfennell/demorepo.wiki
@@ -46,7 +46,7 @@ steps:
       user: rfennell
       password: '$(githubPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\githubrepo'
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
     displayName: 'Git based WIKI Updater - GitHub append'
     inputs:
       repo: github.com/rfennell/demorepo.wiki
@@ -64,7 +64,7 @@ steps:
       user: rfennell
       password: '$(githubPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\githubrepo'
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
     displayName: 'Git based WIKI Updater - GitHub prepend '
     inputs:
       repo: github.com/rfennell/demorepo.wiki
@@ -84,7 +84,7 @@ steps:
       user: rfennell
       password: '$(githubPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\githubrepo'
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
     displayName: 'Git based WIKI Updater - GitHub folder'
     inputs:
       repo: github.com/rfennell/demorepo.wiki
@@ -104,7 +104,7 @@ steps:
       user: rfennell
       password: '$(githubPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\githubrepo'
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
     displayName: 'Git based WIKI Updater - GitHub folder with spaces'
     inputs:
       repo: github.com/rfennell/demorepo.wiki
@@ -125,7 +125,7 @@ steps:
       password: '$(githubPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\githubrepo'
       fixSpaces: true
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
     displayName: 'Git based WIKI Updater - Azure DevOps with Creds update .order file'
     inputs:
       repo: 'dev.azure.com/richardfennell/Git%20project/_git/Git-project.wiki'
@@ -143,7 +143,7 @@ steps:
       password: '$(AzureDevOpsPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\azurerepowithcreds'
       updateOrderFile: true
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
     displayName: 'Git based WIKI Updater - Azure DevOps with Creds update TestFolder/.order file'
     inputs:
       repo: 'dev.azure.com/richardfennell/Git%20project/_git/Git-project.wiki'
@@ -165,7 +165,7 @@ steps:
       appendToFile: false
       injecttoc: true
       orderFilePath: "TestFolder"
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
     displayName: 'Git based WIKI Updater - Azure DevOps in branch'
     inputs:
       repo: 'dev.azure.com/richardfennell/Git%20project/_git/WikiRepo'
@@ -183,7 +183,7 @@ steps:
       password: '$(AzureDevOpsPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\azurerepowithcreds'
       branch: b1
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
     displayName: 'Git based WIKI Updater - Azure DevOps into Folder'
     inputs:
       repo: 'dev.azure.com/richardfennell/Git%20project/_git/Git-project.wiki'
@@ -200,7 +200,7 @@ steps:
       user: richardfennell
       password: '$(AzureDevOpsPAT)'
       localpath: '$(System.DefaultWorkingDirectory)\azurerepowithcreds'
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
     displayName: 'Git based WIKI Updater - Azure DevOps as Agent'
     inputs:
       repo: 'dev.azure.com/richardfennell/GitHub/_git/GitHub.wiki'
@@ -216,7 +216,7 @@ steps:
       gitemail: 'build@demo'
       useAgentToken: true
       localpath: '$(System.DefaultWorkingDirectory)\azurerepoasagent'
-  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
+  - task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
     displayName: 'Git based WIKI Updater - Azure DevOps as Agent with full url'
     inputs:
       repo: 'https://richardfennell@dev.azure.com/richardfennell/GitHub/_git/GitHub.wiki'

--- a/YAMLTemplates/generate-wiki-docs.yml
+++ b/YAMLTemplates/generate-wiki-docs.yml
@@ -23,7 +23,7 @@ steps:
     filePrefix: '${{parameters.wikiFilename}}'    
     copyReadme: true
 
-- task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
+- task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
   displayName: 'Git based WIKI Updater - Readme'
   inputs:
     repo: '${{parameters.repo}}'
@@ -36,7 +36,7 @@ steps:
     user: '${{parameters.UserName}}'
     password: '${{parameters.GitHubPat}}'
 
-- task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
+- task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
   displayName: 'Git based WIKI Updater - YAML '
   inputs:
     repo: '${{parameters.repo}}'

--- a/YAMLTemplates/generate-wiki-docs.yml
+++ b/YAMLTemplates/generate-wiki-docs.yml
@@ -23,7 +23,7 @@ steps:
     filePrefix: '${{parameters.wikiFilename}}'    
     copyReadme: true
 
-- task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
+- task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
   displayName: 'Git based WIKI Updater - Readme'
   inputs:
     repo: '${{parameters.repo}}'
@@ -36,7 +36,7 @@ steps:
     user: '${{parameters.UserName}}'
     password: '${{parameters.GitHubPat}}'
 
-- task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@2
+- task: richardfennellBM.BM-VSTS-WIKIUpdater-Tasks-DEV.WikiUpdaterTask.WikiUpdaterTask@3
   displayName: 'Git based WIKI Updater - YAML '
   inputs:
     repo: '${{parameters.repo}}'


### PR DESCRIPTION
Remove V2 Agent (Node10 execution engine) support for the WIKI related tasks WIKIPDFExporter and the two WIKIUploader tasks.

This is to allow the update of the rimraf library to a later version than 3.0.2 (V4 and later need Node14 and later)