### PR TITLE
add guard clause to skip artifact with missing build associated

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/src/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/src/ReleaseNotesFunctions.ts
@@ -210,8 +210,11 @@ export async function restoreAzurePipelineArtifactsBuildInfo(artifactsInRelease:
                 const [packageId, packageVersion] = [artifactInRelease.buildDefinitionId, artifactInRelease.buildNumber];
                 const artifactPackageInfo = await packagingApi.getPackage(projectId, feedId, packageId, true);
                 const packageVersionId = (artifactPackageInfo.versions.find((version) => version.normalizedVersion === packageVersion) || {id: ""}).id;
-                const artifactBuildInfo = (await packagingApi.getPackageVersionProvenance(projectId, feedId, packageId, packageVersionId));
-
+                const artifactBuildInfo = await packagingApi.getPackageVersionProvenance(projectId, feedId, packageId, packageVersionId);
+                if (!artifactBuildInfo.provenance.data["Build.BuildId"]) {
+                agentApi.logInfo(`No build ID found for Azure Artifact [${artifactInRelease.artifactAlias}]. Skipping this artifact.`);
+                continue; // Guard clause for missing build ID
+                }
                 Object.assign(artifactInRelease, {
                     artifactType: "Build",
                     buildId: artifactBuildInfo.provenance.data["Build.BuildId"],


### PR DESCRIPTION
### What problem does this PR address?
Azure DevOps Extensions - Generate Release Notes (Node Cross Platform)
Adding guard clause to solve issue with manually uploaded artifacts which don't have build id associated
  
### Is there a related Issue?
#1966 
  
### Have you...
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
