### PR TITLE
add html encoding for project when getting consumed artifacts

### DIFF
--- a/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/src/ReleaseNotesFunctions.ts
+++ b/Extensions/XplatGenerateReleaseNotes/XplatGenerateReleaseNotesTask/src/ReleaseNotesFunctions.ts
@@ -673,6 +673,7 @@ export async function getConsumedArtifactsForBuild(
 ): Promise<[]> {
     return new Promise<[]>(async (resolve, reject) => {
         let consumedArtifacts: [] = [];
+        var result;
         try {
             var payload = {
                 "contributionIds": [
@@ -694,13 +695,22 @@ export async function getConsumedArtifactsForBuild(
                     }
                 }
             };
+
+            tl.debug(`Request payload: ${JSON.stringify(payload)}`);
+
+            var teamProjectEncoded = encodeURIComponent(teamProject);
+            var url = `${tpcUri}/_apis/Contribution/HierarchyQuery/project/${teamProjectEncoded}?api-version=5.1-preview`;
+            tl.debug(`Request URL: ${url}`);
             let response = await restClient.create(
-                `${tpcUri}/_apis/Contribution/HierarchyQuery/project/${teamProject}?api-version=5.1-preview`,
+                url,
                 payload);
-            var result = response.result;
+            tl.debug(`Request response: ${JSON.stringify(response)}`);
+            result = response.result;
+            tl.debug(`Request response.result: ${JSON.stringify(result)}`);
             resolve(response.result["dataProviders"]["ms.vss-build-web.run-consumed-artifacts-data-provider"].consumedSources);
         } catch (err) {
             tl.warning(`Cannot get the details of the consumed artifacts ${err}`);
+            tl.warning(`API call result was ${JSON.stringify(result)}`);
             resolve([]);
         }
     });


### PR DESCRIPTION
### What problem does this PR address?
**GenerateReleaseNotes (XPlat version)**
Resolves #2021 by html encoding the `teamProject` variable before it is used to create the request url for getting consumed artifacts.
It also adds some debugging messages and additional warning information in case the request or the subsequent processing of the request result fails.
  
### Is there a related Issue?
#2021
  
### Have you...
- If you are willing, please enable me, as the Repo owner, to [edit your fork that contains your PR](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) so I can add any missing items such as the readme.md
