### PR TITLE
Add Node20 support

### DIFF
--- a/Extensions/WikiUpdater/WikiFolderUpdaterTask/WikiFolderUpdaterTaskV3/task/task.json
+++ b/Extensions/WikiUpdater/WikiFolderUpdaterTask/WikiFolderUpdaterTaskV3/task/task.json
@@ -213,5 +213,10 @@
       "target": "GitWikiTask.js",
       "argumentFormat": ""
     }
+    ,
+    "Node20_1": {
+      "target": "GitWikiTask.js",
+      "argumentFormat": ""
+  }
   }
 }

--- a/Extensions/WikiUpdater/WikiUpdaterTask/WikiUpdaterTaskV3/task/task.json
+++ b/Extensions/WikiUpdater/WikiUpdaterTask/WikiUpdaterTaskV3/task/task.json
@@ -302,6 +302,10 @@
       "Node16": {
       "target": "GitWikiTask.js",
       "argumentFormat": ""
+    },
+    "Node20_1": {
+      "target": "GitWikiTask.js",
+      "argumentFormat": ""
     }
 
   }


### PR DESCRIPTION
Added the runner execution block for the V3 tasks to  Node20, but leaving  the existing execution blocks for Node16. They  use JS scripts file.

fixes #2106