### PR TITLE
Add Node20 support

### DIFF
--- a/Extensions/BuildUpdating/BuildRetensionTask/task/task.json
+++ b/Extensions/BuildUpdating/BuildRetensionTask/task/task.json
@@ -84,6 +84,11 @@
       "target": "$(currentDirectory)/BuildRetensionTask.js",
       "argumentFormat": "",
       "workingDirectory": "$(currentDirectory)"
+    },
+    "Node20_1": {
+      "target": "$(currentDirectory)/BuildRetensionTask.js",
+      "argumentFormat": "",
+      "workingDirectory": "$(currentDirectory)"
     }
 
   }

--- a/Extensions/BuildUpdating/BuildVariableTask/task/task.json
+++ b/Extensions/BuildUpdating/BuildVariableTask/task/task.json
@@ -105,6 +105,11 @@
       "target": "$(currentDirectory)/BuildVariableTask.js",
       "argumentFormat": "",
       "workingDirectory": "$(currentDirectory)"
+    },
+    "Node20_1": {
+      "target": "$(currentDirectory)/BuildVariableTask.js",
+      "argumentFormat": "",
+      "workingDirectory": "$(currentDirectory)"
     }
 
   }

--- a/Extensions/BuildUpdating/GetBuildDefinitionVariableValueTask/task/task.json
+++ b/Extensions/BuildUpdating/GetBuildDefinitionVariableValueTask/task/task.json
@@ -78,6 +78,11 @@
       "target": "$(currentDirectory)/GetBuildVariableTask.js",
       "argumentFormat": "",
       "workingDirectory": "$(currentDirectory)"
+    },
+    "Node20_1": {
+      "target": "$(currentDirectory)/GetBuildVariableTask.js",
+      "argumentFormat": "",
+      "workingDirectory": "$(currentDirectory)"
     }
 
   }

--- a/Extensions/BuildUpdating/azure-pipelines.yml
+++ b/Extensions/BuildUpdating/azure-pipelines.yml
@@ -123,9 +123,9 @@ stages:
             scriptType: pscore
             scriptLocation: inlineScript
             inlineScript: |
-              $resourceGroup = $(resourceGroup)
-              $devTestLabName = $(devTestLabName)
-              $vmName = $(vmName)
+              $resourceGroup = "$(resourceGroup)"
+              $devTestLabName = "$(devTestLabName)"
+              $vmName = "$(vmName)"
               $vmAction = "Start" # or Stop
                  
               az lab vm $vmAction --lab-name  $devTestLabName --name $vmName  --resource-group $resourceGroup 

--- a/Extensions/BuildUpdating/azure-pipelines.yml
+++ b/Extensions/BuildUpdating/azure-pipelines.yml
@@ -116,10 +116,19 @@ stages:
       pool:
         vmImage: '$(vmImage)'
       steps:
-        - task: richardfennellBM.BM-VSTS-DevTestLab-DEV.DevTestLabsStartVm.DevTestLabsStartVm@1
+        - task: AzureCLI@2
           displayName: 'Start a DevTest Labs VM'
           inputs:
-            ConnectedServiceName: 'RF MVP Visual Studio Enterprise (74b7c35f-1dd9-45d0-bf0c-4a8fbe3d9cb8) Service Principal'
+            azureSubscription:  'RF MVP Visual Studio Enterprise (74b7c35f-1dd9-45d0-bf0c-4a8fbe3d9cb8) Service Principal'
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              $resourceGroup = $(resourceGroup)
+              $devTestLabName = $(devTestLabName)
+              $vmName = $(vmName)
+              $vmAction = "Start" # or Stop
+                 
+              az lab vm $vmAction --lab-name  $devTestLabName --name $vmName  --resource-group $resourceGroup 
 
     - deployment: Private_Test
       timeoutInMinutes: 0


### PR DESCRIPTION
Added the runner execution block for Node20, but leaving all the existing execution blocks for Node16 and Node 10. They all use JS scripts file.

fixes #2106
