### PR TITLE
Add Node20 support

### DIFF
--- a/Extensions/ArtifactDescription/ArtifactDescriptionTask/task/task.json
+++ b/Extensions/ArtifactDescription/ArtifactDescriptionTask/task/task.json
@@ -44,6 +44,10 @@
     "Node16": {
       "target": "ArtifactDescriptionTask.js",
       "argumentFormat": ""
+    },
+    "Node20_1": {
+      "target": "ArtifactDescriptionTask.js",
+      "argumentFormat": ""
     }
 
   }


### PR DESCRIPTION
Added the runner execution block for Node20, but leaving all the existing execution blocks for Node16 and Node 10. They all use JS scripts file.

fixes #2106