### PR TITLE
Add Node20 support

### DIFF
--- a/Extensions/YamlGenerator/YamlGeneratorTask/task/task.json
+++ b/Extensions/YamlGenerator/YamlGeneratorTask/task/task.json
@@ -69,6 +69,10 @@
     "Node16": {
       "target": "Generate-YAMLDocumentation.js",
       "argumentFormat": ""
+    },
+    "Node20_1": {
+      "target": "Generate-YAMLDocumentation.js",
+      "argumentFormat": ""
     }
   }
 }


### PR DESCRIPTION
Added the runner execution block for Node20, but leaving all the existing execution blocks for Node16 and Node 10. They all use JS scripts file.

fixes #2106