### PR TITLE
Add Node20 Support

### DIFF
--- a/Extensions/WikiPDFExport/WikiPDFExportTask/WikiPDFExportTaskV4/task/task.json
+++ b/Extensions/WikiPDFExport/WikiPDFExportTask/WikiPDFExportTaskV4/task/task.json
@@ -165,6 +165,10 @@
     "Node16": {
       "target": "WikiPDFExportTask.js",
       "argumentFormat": ""
+    },
+    "Node20_1": {
+      "target": "WikiPDFExportTask.js",
+      "argumentFormat": ""
     }
   }
 }

--- a/Extensions/WikiPDFExport/WikiPDFExportTask/WikiPDFExportTaskV4/task/task.json
+++ b/Extensions/WikiPDFExport/WikiPDFExportTask/WikiPDFExportTaskV4/task/task.json
@@ -165,7 +165,8 @@
     "Node16": {
       "target": "WikiPDFExportTask.js",
       "argumentFormat": ""
-    },
+    }
+    ,
     "Node20_1": {
       "target": "WikiPDFExportTask.js",
       "argumentFormat": ""


### PR DESCRIPTION
Added the runner execution block for Node20, but leaving all the existing execution blocks for Node16. They all use JS scripts file.

Fixes #2106
