### PR TITLE
Add Node20 support

### DIFF
--- a/Extensions/Sarif2JUnitConverter/Sarif2JUnitConverterTask/task/task.json
+++ b/Extensions/Sarif2JUnitConverter/Sarif2JUnitConverterTask/task/task.json
@@ -44,6 +44,10 @@
     "Node16": {
       "target": "Sarif2JUnitConverter.js",
       "argumentFormat": ""
+    },
+    "Node20_1": {
+      "target": "Sarif2JUnitConverter.js",
+      "argumentFormat": ""
     }
   }
 }


### PR DESCRIPTION
Added the runner execution block for Node20, but leaving all the existing execution blocks for Node16 and Node 10. They all use JS scripts file.

Fixes #2106 
